### PR TITLE
Create AreaField and SliderField

### DIFF
--- a/DynamicLights/Fields/AreaField.qml
+++ b/DynamicLights/Fields/AreaField.qml
@@ -1,0 +1,46 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+
+import "../Style"
+
+Field {
+    id: areaField
+
+    property string placeholder: "Area Field"
+    property string defaultText: "Area Field"
+
+    TextArea {
+        id: textArea
+
+        // root settings
+        text: defaultText
+        placeholderText: placeholder
+        wrapMode: TextEdit.WordWrap
+
+        // alignments
+        width: fieldWidth
+        Layout.fillHeight: true
+        leftPadding: 0
+        rightPadding: 0
+        topPadding: Stylesheet.field.padding_TB
+        bottomPadding: Stylesheet.field.padding_TB
+
+        // background
+        background: FieldFrame {
+            frameWidth: fieldWidth
+            isHovered: textArea.hovered
+            isFocused: textArea.activeFocus
+        }
+
+        // font & color
+        font {
+            family: Stylesheet.fonts.main
+            pixelSize: 14
+        }
+        color: Stylesheet.colors.white
+
+        // mouse interaction
+        selectByMouse: true
+    }
+}

--- a/DynamicLights/Fields/AreaField.qml
+++ b/DynamicLights/Fields/AreaField.qml
@@ -10,37 +10,51 @@ Field {
     property string placeholder: "Area Field"
     property string defaultText: "Area Field"
 
-    TextArea {
-        id: textArea
-
-        // root settings
-        text: defaultText
-        placeholderText: placeholder
-        wrapMode: TextEdit.WordWrap
-
-        // alignments
-        width: fieldWidth
+    Item {
+        Layout.fillWidth: true
         Layout.fillHeight: true
-        leftPadding: 0
-        rightPadding: 0
-        topPadding: Stylesheet.field.padding
-        bottomPadding: Stylesheet.field.padding
 
-        // background
-        background: FieldFrame {
-            frameWidth: fieldWidth
+        FieldFrame {
+            anchors.fill: parent
             isHovered: textArea.hovered
             isFocused: textArea.activeFocus
         }
 
-        // font & color
-        font {
-            family: Stylesheet.fonts.main
-            pixelSize: 14
-        }
-        color: Stylesheet.colors.white
+        Flickable {
+            id: flickable
+            anchors.fill: parent
+            maximumFlickVelocity: 350
 
-        // mouse interaction
-        selectByMouse: true
+            TextArea.flickable: TextArea {
+                id: textArea
+
+                // root settings
+                text: defaultText
+                placeholderText: placeholder
+                wrapMode: TextArea.Wrap
+
+                // alignments
+                width: fieldWidth
+                leftPadding: 0
+                rightPadding: 0
+                topPadding: Stylesheet.field.padding
+                bottomPadding: Stylesheet.field.padding
+
+                // background
+                background: Rectangle { opacity: 0 }
+
+                // font & color
+                font {
+                    family: Stylesheet.fonts.main
+                    pixelSize: 14
+                }
+                color: Stylesheet.colors.white
+
+                // mouse interaction
+                selectByMouse: true
+            }
+
+            ScrollBar.vertical: ScrollBar {}
+        }
     }
 }

--- a/DynamicLights/Fields/AreaField.qml
+++ b/DynamicLights/Fields/AreaField.qml
@@ -15,7 +15,6 @@ Field {
         Layout.fillHeight: true
 
         FieldFrame {
-            anchors.fill: parent
             isHovered: textArea.hovered
             isFocused: textArea.activeFocus
         }

--- a/DynamicLights/Fields/AreaField.qml
+++ b/DynamicLights/Fields/AreaField.qml
@@ -23,8 +23,8 @@ Field {
         Layout.fillHeight: true
         leftPadding: 0
         rightPadding: 0
-        topPadding: Stylesheet.field.padding_TB
-        bottomPadding: Stylesheet.field.padding_TB
+        topPadding: Stylesheet.field.padding
+        bottomPadding: Stylesheet.field.padding
 
         // background
         background: FieldFrame {

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -1,7 +1,6 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.2
 import QtQuick.Layouts 1.3
-import QtQuick.Controls.Styles 1.4
 
 import "../Style"
 
@@ -10,8 +9,9 @@ ColumnLayout {
 
     property string labelText: "Label"
     property int fieldWidth: 200
-    property alias fieldContent: fieldLoader.sourceComponent
 
+    width: fieldWidth
+    implicitHeight: fieldLabel.height + 45
     spacing: 5
 
     // top label
@@ -26,7 +26,4 @@ ColumnLayout {
             capitalization: Font.AllUppercase
         }
     }
-
-    // field
-    Loader { id: fieldLoader }
 }

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -10,9 +10,10 @@ ColumnLayout {
     property string labelText: "Label"
     property int fieldWidth: 200
 
-    width: fieldWidth
+    implicitWidth: fieldWidth
     implicitHeight: fieldLabel.height + 45
     spacing: 5
+    Layout.alignment: Qt.AlignLeft | Qt.AlignTop
 
     // top label
     Label {

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -10,10 +10,11 @@ ColumnLayout {
     property string labelText: "Label"
     property int fieldWidth: 200
 
-    implicitWidth: fieldWidth
-    implicitHeight: fieldLabel.height + 45
-    spacing: 5
     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+    Layout.preferredWidth: fieldWidth
+    Layout.preferredHeight: fieldLabel.height + 45
+
+    spacing: 5
 
     // top label
     Label {

--- a/DynamicLights/Fields/FieldFrame.qml
+++ b/DynamicLights/Fields/FieldFrame.qml
@@ -11,6 +11,7 @@ Item {
 
     Repeater {
         model: ["top", "bottom"]
+
         Rectangle {
             width: parent.width
             height: 1

--- a/DynamicLights/Fields/FieldFrame.qml
+++ b/DynamicLights/Fields/FieldFrame.qml
@@ -8,6 +8,7 @@ Item {
     property bool isFocused: false
 
     implicitWidth: frameWidth
+    implicitHeight: 40
 
     Repeater {
         model: ["top", "bottom"]

--- a/DynamicLights/Fields/FieldFrame.qml
+++ b/DynamicLights/Fields/FieldFrame.qml
@@ -9,6 +9,7 @@ Item {
 
     implicitWidth: frameWidth
     implicitHeight: 40
+    anchors.fill: parent
 
     Repeater {
         model: ["top", "bottom"]

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -45,11 +45,10 @@ Field {
 
             // item background
             background: Rectangle {
+                anchors.fill: parent
                 color: Stylesheet.colors.white
                 opacity: hovered ? 0.1 : 0
                 border.width: 0
-                width: parent.width
-                height: parent.height
             }
         }
 

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -40,10 +40,7 @@ Field {
                 opacity: hovered ? 1 : 0.5
                 font.family: comboBox.font.family
                 font.pixelSize: 14
-                leftPadding: 8
-                rightPadding: 8
-                topPadding: Stylesheet.field.padding_TB
-                bottomPadding: Stylesheet.field.padding_TB
+                padding: Stylesheet.field.padding
             }
 
             // item background
@@ -59,9 +56,8 @@ Field {
         // selected item contents
         contentItem: Label {
             text: comboBox.displayText
-
-            topPadding: Stylesheet.field.padding_TB
-            bottomPadding: Stylesheet.field.padding_TB
+            verticalAlignment: Text.AlignVCenter
+            height: 40
 
             color: Stylesheet.colors.white
         }
@@ -90,7 +86,6 @@ Field {
         indicator: Image {
             anchors.right: parent.right
             anchors.verticalCenter: parent.verticalCenter
-            anchors.rightMargin: Stylesheet.field.padding_LR
             id: indicator
             source: "qrc:/assets/images/down-caret.svg"
 

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -10,7 +10,7 @@ Field {
     property int index: 0
     property variant options: ["A", "B", "C"]
 
-    fieldContent: ComboBox {
+    ComboBox {
         id: comboBox
 
         // root settings
@@ -23,7 +23,7 @@ Field {
 
         // background
         background: FieldFrame {
-            // frameWidth: fieldWidth
+            frameWidth: fieldWidth
             isHovered: comboBox.hovered
         }
 

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -10,7 +10,12 @@ Field {
     property real minVal: 0.0
     property real maxVal: 1.0
     property real currVal: 0.5
+    property real exponent: 1.0
     property real step: 0.0
+
+    function parseValue(v) {
+        return v.toFixed(2 - Math.floor(Math.log10(v < 1 ? 1 : v)))
+    }
 
     Item {
         Layout.fillWidth: true
@@ -18,12 +23,13 @@ Field {
 
         // background
         FieldFrame {
-            isHovered: fieldSlider.hovered
-            isFocused: fieldSlider.pressed
+            isHovered: fieldSlider.hovered || sliderValue.hovered
+            isFocused: fieldSlider.pressed || sliderValue.activeFocus
         }
 
         // main slider area
         RowLayout {
+            id: sliderContainer
             anchors.fill: parent
 
             // slider
@@ -60,22 +66,20 @@ Field {
                 onValueChanged: currVal = value;
             }
 
-            // slider value indicator
-            Text {
+            TextField {
                 id: sliderValue
 
                 // alignment
+                padding: 0
                 Layout.leftMargin: 0
                 Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
-                Layout.preferredWidth: 40
+                Layout.preferredWidth: 50
 
                 // text
-                text: {
-                    if (currVal < 10) return currVal.toFixed(2)
-                    if (currVal >= 10 && currVal < 100) return currVal.toFixed(1)
-                    if (currVal >= 100) return currVal
-                }
+                text: parseValue(currVal)
                 horizontalAlignment: Text.AlignRight
+                validator: RegExpValidator { regExp: /\d*.*\d*/ }
+                selectByMouse: true
 
                 // font and color
                 font {
@@ -83,7 +87,16 @@ Field {
                     weight: Font.Bold
                     pixelSize: 16
                 }
+                background: Rectangle { opacity: 0 }
                 color: Stylesheet.colors.white
+
+                // signals
+                onEditingFinished: {
+                    if (displayText === "") currVal = (minVal + maxVal) / 2;
+                    else if (displayText > maxVal) currVal = maxVal;
+                    else if (displayText < minVal) currVal = minVal;
+                    else currVal = displayText;
+                }
             }
         }
     }

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -1,0 +1,91 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+
+import "../Style"
+
+Field {
+    id: sliderField
+
+    property real minVal: 0.0
+    property real maxVal: 1.0
+    property real currVal: 0.5
+    property real step: 0.0
+
+    Item {
+        width: parent.width
+        height: 40
+
+        // background
+        FieldFrame {
+            anchors.fill: parent
+            isHovered: fieldSlider.hovered
+            isFocused: fieldSlider.pressed
+        }
+
+        // main slider area
+        RowLayout {
+            anchors.fill: parent
+
+            // slider
+            Slider {
+                id: fieldSlider
+
+                // alignment
+                Layout.fillWidth: true
+
+                // slider params
+                from: minVal
+                to: maxVal
+                value: currVal
+                stepSize: step
+
+                // value bar
+                background: Rectangle {
+                    width: parent.width
+                    height: 10
+                    color: "#4D4D4D"
+
+                    Rectangle {
+                        width: parent.width * fieldSlider.visualPosition
+                        anchors.left: parent.left
+                        height: parent.height
+                        color: Stylesheet.colors.outputs[0]
+                    }
+                }
+
+                // no handle
+                handle: Rectangle {}
+
+                // signals
+                onValueChanged: currVal = value;
+            }
+
+            // slider value indicator
+            Text {
+                id: sliderValue
+
+                // alignment
+                Layout.leftMargin: 0
+                Layout.alignment: Qt.AlignRight | Qt.AlignVCenter
+                Layout.preferredWidth: 40
+
+                // text
+                text: {
+                    if (currVal < 10) return currVal.toFixed(2)
+                    if (currVal >= 10 && currVal < 100) return currVal.toFixed(1)
+                    if (currVal >= 100) return currVal
+                }
+                horizontalAlignment: Text.AlignRight
+
+                // font and color
+                font {
+                    family: Stylesheet.fonts.main
+                    weight: Font.Bold
+                    pixelSize: 16
+                }
+                color: Stylesheet.colors.white
+            }
+        }
+    }
+}

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -13,12 +13,11 @@ Field {
     property real step: 0.0
 
     Item {
-        width: parent.width
+        Layout.fillWidth: true
         height: 40
 
         // background
         FieldFrame {
-            anchors.fill: parent
             isHovered: fieldSlider.hovered
             isFocused: fieldSlider.pressed
         }

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -32,7 +32,6 @@ Field {
 
         // background
         background: FieldFrame {
-            frameWidth: fieldWidth
             isHovered: fieldInput.hovered
             isFocused: fieldInput.activeFocus
         }

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -10,7 +10,7 @@ Field {
     property string placeholder: ""
     property string defaultText: "Text Field"
 
-    fieldContent: TextField {
+    TextField {
         id: fieldInput
 
         // alignment
@@ -34,8 +34,8 @@ Field {
 
         // background
         background: FieldFrame {
-            // frameWidth: fieldWidth
-            isHovered: hovered
+            frameWidth: fieldWidth
+            isHovered: fieldInput.hovered
             isFocused: fieldInput.activeFocus
         }
 

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -16,12 +16,11 @@ Field {
         // alignment
         Layout.fillWidth: true
         leftPadding: 0
-        rightPadding: 0
-        topPadding: Stylesheet.field.padding_TB
-        bottomPadding: Stylesheet.field.padding_TB
+        height: 40
 
         // text
         text: defaultText
+
         placeholderText: placeholder
 
         // font + color
@@ -30,7 +29,6 @@ Field {
             pixelSize: 18
         }
         color: Stylesheet.colors.white
-        // placeholderTextColor: Stylesheet.setAlpha(Stylesheet.colors.white, 0.4)
 
         // background
         background: FieldFrame {

--- a/DynamicLights/GeneratorWidget.qml
+++ b/DynamicLights/GeneratorWidget.qml
@@ -16,7 +16,6 @@ Button {
 
     // state props
     property bool selected: false
-    property bool hovering: false
 
     width: parent.width
     height: 55
@@ -41,14 +40,14 @@ Button {
     }
 
 
-
     // TODO: graph
 
     // text content
-    contentItem: RowLayout {
+    RowLayout {
         spacing: 0
         anchors.leftMargin: 10
         anchors.fill: parent
+        Layout.alignment: Qt.AlignVCenter
 
         // index
         Label {
@@ -61,7 +60,7 @@ Button {
                 weight: Font.Bold
                 pixelSize: 11
             }
-            opacity: selected ? 1 : (hovering ? 1 : 0.5)
+            opacity: selected ? 1 : (hovered ? 1 : 0.5)
         }
 
         // generator name
@@ -76,7 +75,7 @@ Button {
                 weight: Font.Normal
                 pixelSize: 18
             }
-            opacity: selected ? 1 : (hovering ? 1 : 0.5)
+            opacity: selected ? 1 : (hovered ? 1 : 0.5)
         }
 
         // output indicator
@@ -91,15 +90,5 @@ Button {
         }
     }
 
-    // event management
-    MouseArea {
-        id: btnMouseArea
-
-        anchors.fill: parent
-        hoverEnabled: true
-
-        onClicked: selected = !selected
-        onEntered: hovering = true
-        onExited: hovering = false
-    }
+    onClicked: selected = !selected
 }

--- a/DynamicLights/Racks/GenRack.qml
+++ b/DynamicLights/Racks/GenRack.qml
@@ -10,7 +10,7 @@ Rack {
 
     content: RowLayout {
         Layout.fillWidth: true
-        spacing: 20
+        spacing: 30
 
         ColumnLayout {
             spacing: 30;
@@ -25,6 +25,15 @@ Rack {
                 labelText: "Type"
                 options: ["SNN"]
             }
+        }
+
+        AreaField {
+            labelText: "Description"
+            placeholder: "Enter description here"
+            defaultText: "This is a description for the Spiking Neural Network (SNN) generator. This algorithm creates short peaks generatively over time."
+
+            fieldWidth: 400
+            height: parent.height
         }
     }
 }

--- a/DynamicLights/Racks/GenRack.qml
+++ b/DynamicLights/Racks/GenRack.qml
@@ -34,7 +34,6 @@ Rack {
             defaultText: "This is a description for the Spiking Neural Network (SNN) generator. This algorithm creates short peaks generatively over time."
 
             fieldWidth: 400
-            height: parent.height
         }
 
         ColumnLayout {

--- a/DynamicLights/Racks/GenRack.qml
+++ b/DynamicLights/Racks/GenRack.qml
@@ -10,10 +10,11 @@ Rack {
 
     content: RowLayout {
         Layout.fillWidth: true
+
         spacing: 30
 
         ColumnLayout {
-            spacing: 30;
+            spacing: 30
 
             TextField {
                 labelText: "Name"
@@ -35,5 +36,24 @@ Rack {
             fieldWidth: 400
             height: parent.height
         }
+
+        ColumnLayout {
+            spacing: 30
+
+            SliderField {
+                labelText: "Ratio"
+                step: 0.05
+            }
+
+            SliderField {
+                labelText: "Ratio 2"
+                minVal: 10
+                maxVal: 110
+                currVal: 20
+                step: 1
+            }
+        }
+
+
     }
 }

--- a/DynamicLights/Racks/GenRack.qml
+++ b/DynamicLights/Racks/GenRack.qml
@@ -42,6 +42,7 @@ Rack {
             SliderField {
                 labelText: "Ratio"
                 step: 0.05
+                exponent: 2.0
             }
 
             SliderField {

--- a/DynamicLights/Racks/Rack.qml
+++ b/DynamicLights/Racks/Rack.qml
@@ -70,6 +70,8 @@ ColumnLayout {
             anchors.fill: parent
             spacing: 0
 
+            Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+
             // field content
             Loader { id: contentLoader }
         }

--- a/DynamicLights/Style/Stylesheet.qml
+++ b/DynamicLights/Style/Stylesheet.qml
@@ -28,8 +28,7 @@ QtObject {
 
     // SPACINGS
     property QtObject field: QtObject {
-        //readonly property int padding_LR: 0
-        readonly property int padding_TB: 8
+        readonly property int padding: 8
     }
 
     // TOOLS

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -46,7 +46,7 @@ int main(int argc, char *argv[])
     // load fonts in the project database
     QDir fontDir{":/assets/fonts"};
     for (auto file : fontDir.entryList(QDir::Files)) {
-        if (QFontDatabase::addApplicationFont(":/assets/fonts/" + file))
+        if (QFontDatabase::addApplicationFont(":/assets/fonts/" + file) == -1)
             standardOutput << "Failed to load font " << file << endl;
     }
 

--- a/DynamicLights/qml.qrc
+++ b/DynamicLights/qml.qrc
@@ -14,6 +14,7 @@
         <file>assets/images/light-cue@2x.png</file>
         <file>assets/images/light-cue@3x.png</file>
         <file>assets/images/light-cue@4x.png</file>
+        <file>Fields/AreaField.qml</file>
         <file>Fields/Field.qml</file>
         <file>Fields/FieldFrame.qml</file>
         <file>Fields/SelectField.qml</file>

--- a/DynamicLights/qml.qrc
+++ b/DynamicLights/qml.qrc
@@ -18,6 +18,7 @@
         <file>Fields/Field.qml</file>
         <file>Fields/FieldFrame.qml</file>
         <file>Fields/SelectField.qml</file>
+        <file>Fields/SliderField.qml</file>
         <file>Fields/TextField.qml</file>
         <file>Style/qmldir</file>
         <file>Style/Stylesheet.qml</file>


### PR DESCRIPTION
This PR adds two new fields to the application's widget toolbox:
![Screenshot_1](https://user-images.githubusercontent.com/34627009/85229514-0526ba80-b3b8-11ea-8032-b13d27d62fea.png)
- `AreaField.qml`: an editable, multi-line input field with auto-scrolling overflow mechanics;
- `SliderField.qml`: a numerical slider that can be mapped between two boundary values and with a set step size.

A few bug fixes on `GeneratorWidget` and most field components were also applied.