### PR TITLE
Fix output monitor auto-updating

### DIFF
--- a/DynamicLights/GeneratorModel.cpp
+++ b/DynamicLights/GeneratorModel.cpp
@@ -3,6 +3,12 @@
 
 GeneratorModel::GeneratorModel(QList<QSharedPointer<Generator>> generators) {
     this->generators = generators;
+
+    for(int i = 0; i < generators.count(); i++) {
+        connect(generators[i].get(), &Generator::outputMonitorChanged, this, [=]() {
+            emit dataChanged(index(i), index(0), { OutputMonitorRole });
+        });
+    }
 }
 
 int GeneratorModel::rowCount(const QModelIndex& parent) const {


### PR DESCRIPTION
This PR fixes bug #74 by hooking the `Generator::outputMonitorChanged` and `GeneratorModel::dataChanged` signals together.