### PR TITLE
Normalized SNN output and exposed SNN properties

### DIFF
--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -55,7 +55,6 @@ void ComputeEngine::run() {
         outputMonitor /= (*it)->getOutputSize();
         // maybe doing this here is bad? does the overhead of the signaling slow down the loop?
         (*it)->writeOutputMonitor(outputMonitor);
-        qDebug() << outputMonitor;
     }
 
     // measure the time used to do the computation

--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -55,6 +55,7 @@ void ComputeEngine::run() {
         outputMonitor /= (*it)->getOutputSize();
         // maybe doing this here is bad? does the overhead of the signaling slow down the loop?
         (*it)->writeOutputMonitor(outputMonitor);
+        qDebug() << outputMonitor;
     }
 
     // measure the time used to do the computation

--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -45,7 +45,9 @@ void ComputeEngine::run() {
     // do the computation
     for(QList<QSharedPointer<Generator>>::iterator it = generators.begin(); it != generators.end(); it++) {
         // do the actual computation
-        (*it)->computeOutput(millisLastFrame / 1000.0);
+        //(*it)->computeOutput(millisLastFrame / 1000.0);
+        // deterministic patch
+        (*it)->computeOutput(1.0 / frequency);
         // update the value of the output monitor
         double outputMonitor = 0;
         for(int i = 0; i < (*it)->getOutputSize(); i++) {
@@ -55,6 +57,7 @@ void ComputeEngine::run() {
         outputMonitor /= (*it)->getOutputSize();
         // maybe doing this here is bad? does the overhead of the signaling slow down the loop?
         (*it)->writeOutputMonitor(outputMonitor);
+        qDebug() << outputMonitor;
     }
 
     // measure the time used to do the computation

--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -45,8 +45,6 @@ void ComputeEngine::run() {
     // do the computation
     for(QList<QSharedPointer<Generator>>::iterator it = generators.begin(); it != generators.end(); it++) {
         // do the actual computation
-        //(*it)->computeOutput(millisLastFrame / 1000.0);
-        // deterministic patch
         (*it)->computeOutput(1.0 / frequency);
         // update the value of the output monitor
         double outputMonitor = 0;

--- a/DynamicLights/GeneratorModel.cpp
+++ b/DynamicLights/GeneratorModel.cpp
@@ -6,7 +6,7 @@ GeneratorModel::GeneratorModel(QList<QSharedPointer<Generator>> generators) {
 
     for(int i = 0; i < generators.count(); i++) {
         connect(generators[i].get(), &Generator::outputMonitorChanged, this, [=]() {
-            emit dataChanged(index(i), index(0), { OutputMonitorRole });
+            emit dataChanged(index(i), index(i), { OutputMonitorRole });
         });
     }
 }

--- a/DynamicLights/GeneratorModel.cpp
+++ b/DynamicLights/GeneratorModel.cpp
@@ -3,6 +3,12 @@
 
 GeneratorModel::GeneratorModel(QList<QSharedPointer<Generator>> generators) {
     this->generators = generators;
+
+    for(int i = 0; i < generators.count(); i++) {
+        connect(generators[i].get(), &Generator::outputMonitorChanged, this, [=]() {
+            emit dataChanged(index(i), index(i), { OutputMonitorRole });
+        });
+    }
 }
 
 int GeneratorModel::rowCount(const QModelIndex& parent) const {

--- a/DynamicLights/Izhikevich.cpp
+++ b/DynamicLights/Izhikevich.cpp
@@ -129,6 +129,12 @@ void Izhikevich::setNeuronType(NeuronType type) {
 
 
 void Izhikevich::update(double deltaTime) { 
+    double deltaTimeMillis = deltaTime * 1000.0;
+    v += deltaTimeMillis * 0.5 * (0.04 * v * v + 5 * v + 140 - u + I);
+    v += deltaTimeMillis * 0.5 * (0.04 * v * v + 5 * v + 140 - u + I);
+    u += deltaTimeMillis * a * (b * v - u);
+
+    /*
     bool broken = false;
     if(std::isnan(v)) {
         std::cout << "v / nan / upper block / update " << updateCounter << std::endl;
@@ -193,6 +199,7 @@ void Izhikevich::update(double deltaTime) {
     }
 
     updateCounter++;
+    */
 }
 
 bool Izhikevich::applyFiring() {

--- a/DynamicLights/Izhikevich.cpp
+++ b/DynamicLights/Izhikevich.cpp
@@ -129,45 +129,40 @@ void Izhikevich::setNeuronType(NeuronType type) {
 
 
 void Izhikevich::update(double deltaTime) { 
-
+    /*
     double deltaTimeMillis = deltaTime * 1000.0;
     v += deltaTimeMillis * 0.5 * (0.04 * v * v + 5 * v + 140 - u + I);
     v += deltaTimeMillis * 0.5 * (0.04 * v * v + 5 * v + 140 - u + I);
     u += deltaTimeMillis * a * (b * v - u);
+    */
 
     // TODO: investigate NaN popping up here
-    /*
     bool broken = false;
     if(std::isnan(v)) {
-        std::cout << "v / nan / upper block / update " << updateCounter << std::endl;
+        std::cout << "v / upper block / update " << updateCounter << std::endl;
         broken = true;
     }
     if(std::isnan(u)) {
-        std::cout << "u / nan / upper block / update " << updateCounter << std::endl;
+        std::cout << "u / upper block / update " << updateCounter << std::endl;
         broken = true;
     }
     if(std::isnan(I)) {
-        std::cout << "I / nan / upper block / update " << updateCounter << std::endl;
+        std::cout << "I / upper block / update " << updateCounter << std::endl;
         broken = true;
     }
 
     double deltaTimeMillis = deltaTime * 1000.0;
-
-    if(deltaTimeMillis < deltaTime) {
-        std::cout << "deltaTimeMillis / logical failure / upper block / update " << updateCounter << std::endl;
-        broken = true;
-    }
 
     double deltaV;
     deltaV = deltaTimeMillis * 0.5 * (0.04 * v * v + 5.0 * v + 140.0 - u + I);
     v += deltaV;
 
     if(std::isnan(deltaV)) {
-        std::cout << "deltaV / nan / mid block / update " << updateCounter << std::endl;
+        std::cout << "deltaV / mid block / update " << updateCounter << std::endl;
         broken = true;
     }
     if(std::isnan(v)) {
-        std::cout << "v / nan / mid block / update " << updateCounter << std::endl;
+        std::cout << "v / mid block / update " << updateCounter << std::endl;
         broken = true;
     }
 
@@ -175,11 +170,11 @@ void Izhikevich::update(double deltaTime) {
     v += deltaV;
 
     if(std::isnan(deltaV)) {
-        std::cout << "deltaV / nan / lower block / update " << updateCounter << std::endl;
+        std::cout << "deltaV / lower block / update " << updateCounter << std::endl;
         broken = true;
     }
     if(std::isnan(v)) {
-        std::cout << "v / nan / lower block / update " << updateCounter << std::endl;
+        std::cout << "v / lower block / update " << updateCounter << std::endl;
         broken = true;
     }
 
@@ -188,20 +183,19 @@ void Izhikevich::update(double deltaTime) {
     u += deltaU;
 
     if(std::isnan(deltaU)) {
-        std::cout << "deltaU / nan / lower block / update " << updateCounter << std::endl;
+        std::cout << "deltaU / lower block / update " << updateCounter << std::endl;
         broken = true;
     }
     if(std::isnan(u)) {
-        std::cout << "u / nan / lower block / update " << updateCounter << std::endl;
+        std::cout << "u / lower block / update " << updateCounter << std::endl;
         broken = true;
     }
 
     if(broken) {
-
+        // put a breakpoint here
     }
 
     updateCounter++;
-    */
 }
 
 bool Izhikevich::applyFiring() {

--- a/DynamicLights/Izhikevich.cpp
+++ b/DynamicLights/Izhikevich.cpp
@@ -26,7 +26,6 @@ Izhikevich::Izhikevich() {
     u = b * v;
     I = 0.;
     potentialThreshold = 20.;
-    updateCounter = 0;
 }
 
 Izhikevich::~Izhikevich() {
@@ -129,73 +128,10 @@ void Izhikevich::setNeuronType(NeuronType type) {
 
 
 void Izhikevich::update(double deltaTime) { 
-    /*
     double deltaTimeMillis = deltaTime * 1000.0;
     v += deltaTimeMillis * 0.5 * (0.04 * v * v + 5 * v + 140 - u + I);
     v += deltaTimeMillis * 0.5 * (0.04 * v * v + 5 * v + 140 - u + I);
     u += deltaTimeMillis * a * (b * v - u);
-    */
-
-    // TODO: investigate NaN popping up here
-    bool broken = false;
-    if(std::isnan(v)) {
-        std::cout << "v / upper block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-    if(std::isnan(u)) {
-        std::cout << "u / upper block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-    if(std::isnan(I)) {
-        std::cout << "I / upper block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-
-    double deltaTimeMillis = deltaTime * 1000.0;
-
-    double deltaV;
-    deltaV = deltaTimeMillis * 0.5 * (0.04 * v * v + 5.0 * v + 140.0 - u + I);
-    v += deltaV;
-
-    if(std::isnan(deltaV)) {
-        std::cout << "deltaV / mid block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-    if(std::isnan(v)) {
-        std::cout << "v / mid block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-
-    deltaV = deltaTimeMillis * 0.5 * (0.04 * v * v + 5.0 * v + 140.0 - u + I);
-    v += deltaV;
-
-    if(std::isnan(deltaV)) {
-        std::cout << "deltaV / lower block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-    if(std::isnan(v)) {
-        std::cout << "v / lower block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-
-    double deltaU;
-    deltaU = deltaTimeMillis * a * (b * v - u);
-    u += deltaU;
-
-    if(std::isnan(deltaU)) {
-        std::cout << "deltaU / lower block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-    if(std::isnan(u)) {
-        std::cout << "u / lower block / update " << updateCounter << std::endl;
-        broken = true;
-    }
-
-    if(broken) {
-        // put a breakpoint here
-    }
-
-    updateCounter++;
 }
 
 bool Izhikevich::applyFiring() {

--- a/DynamicLights/Izhikevich.cpp
+++ b/DynamicLights/Izhikevich.cpp
@@ -129,11 +129,13 @@ void Izhikevich::setNeuronType(NeuronType type) {
 
 
 void Izhikevich::update(double deltaTime) { 
+
     double deltaTimeMillis = deltaTime * 1000.0;
     v += deltaTimeMillis * 0.5 * (0.04 * v * v + 5 * v + 140 - u + I);
     v += deltaTimeMillis * 0.5 * (0.04 * v * v + 5 * v + 140 - u + I);
     u += deltaTimeMillis * a * (b * v - u);
 
+    // TODO: investigate NaN popping up here
     /*
     bool broken = false;
     if(std::isnan(v)) {

--- a/DynamicLights/Izhikevich.h
+++ b/DynamicLights/Izhikevich.h
@@ -38,7 +38,6 @@ private:
     NeuronType type;
     double I;
     double a, b, c, d;
-    int updateCounter;
 
 public:
     Izhikevich();

--- a/DynamicLights/Izhikevich.h
+++ b/DynamicLights/Izhikevich.h
@@ -30,9 +30,6 @@ enum NeuronType {
     excitatoryNeuronRandomized
 };
 
-// TODO: REMOVE THIS
-using namespace std;
-
 class Izhikevich {
 private:
     double potentialThreshold;

--- a/DynamicLights/Izhikevich.h
+++ b/DynamicLights/Izhikevich.h
@@ -41,13 +41,14 @@ private:
     NeuronType type;
     double I;
     double a, b, c, d;
+    int updateCounter;
 
 public:
     Izhikevich();
     ~Izhikevich();
 
     void update(double deltaTime);
-    void setParam(NeuronType type, double a, double b, double c, double d, double _u, double _v, double _I);
+    void setParam(NeuronType type, double a, double b, double c, double d, double u, double v, double I);
     void setNeuronType(NeuronType type);
     bool applyFiring(); // checks if the neuron is firing and updates the differential equationa accordingly
     NeuronType getNeuronType();
@@ -65,8 +66,9 @@ public:
     double getU();
     double getV();
     double getI();
-    void setI(double i);
-    void addToI(double a);
+    double getPotentialThreshold();
+    void setI(double I);
+    void addToI(double deltaI);
     
     bool firing;
 

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -27,20 +27,25 @@ SpikingNet::SpikingNet() {
     description = "An interconnected network of biologically-modeled neurons.";
     outputMonitor = 0;
 
-    STDPWindow = 20;
+    initialize();
+}
+
+SpikingNet::~SpikingNet() {
+    reset();
+}
+
+
+void SpikingNet::initialize() {
 
     // set random seed
-    if(flagRandomDevice)
-    {
+    if(flagRandomDevice) {
         std::random_device random;
         randomGenerator.seed(random());
-    }
-    else
-    {
+    } else {
         randomGenerator.seed(randomSeed);
     }
 
-
+    // setup vectors
     neurons.resize(neuronSize);
 
     outputGroupSpiking.resize(outputGroupSize, 0);
@@ -48,74 +53,39 @@ SpikingNet::SpikingNet() {
 
     STDPTimes.resize(neuronSize, 0);
 
-    // STP (according to Science paper)
+    input.resize(inputGroupSize, 0);
+    output.resize(outputGroupSize, 0);
+
+    // allocate memory for STP variables
     STPu = new double[neuronSize];
     STPx = new double[neuronSize];
     STPw = new double[neuronSize];
 
+    // initialize STP variables
+    for(int i = 0; i < neuronSize; ++i) {
+        STPw[i] = 1.0;
+        STPx[i] = 1.0;
+        STPu[i] = 0.0;
+    }
+
+    // allocate memory for weights
     weights = new double*[neuronSize];
     for(int i = 0; i < neuronSize; ++i) {
         weights[i] = new double[neuronSize];
     }
 
-    // setup generator inputs and outputs
-    input.resize(inputGroupSize, 0.0);
-    output.resize(outputGroupSize, 0.0);
-}
-
-SpikingNet::~SpikingNet() {
-
-    // delete STP variables
-    delete[] STPu;
-    delete[] STPx;
-    delete[] STPw;
-    STPu = 0;
-    STPx = 0;
-    STPw = 0;
-
-    for(int i = 0; i < neuronSize; ++i) {
-        delete[] weights[i];
-        weights[i] = 0;
-    }
-    delete[] weights;
-    weights = 0;
-}
-
-
-void SpikingNet::init() {
-
+    // initialize weights
     for(int i = 0; i < neuronSize; ++i) {
         for(int j = 0; j < neuronSize; ++j) {
             weights[i][j] = 0.;
         }
     }
 
-    neurons.clear();
-    STDPTimes.clear();
-
-    neurons.resize(neuronSize);
-
-    outputGroupSpiking.resize(outputGroupSize, 0);
-    outputGroupActivation.resize(outputGroupSize, 0);
-
-    STDPTimes.resize(neuronSize, 0);
-
-    // initialization of some variables
-    for(int i = 0; i < neuronSize; ++i) {
-        // initialize STDP variables
-        STDPTimes[i] = 0;
-
-        // initialize STP variables
-        STPw[i] = 1.0;
-        STPx[i] = 1.0;
-        STPu[i] = 0.0;
-    }
-
     // set neuron types
     for(int i = 0; i < neuronSize; ++i) {
         if(i < inhibitorySize) {
             neurons[i].setNeuronType(inhibitoryNeuronType);
-        }else{
+        } else{
             neurons[i].setNeuronType(excitatoryNeuronType);
         }
     }
@@ -128,13 +98,31 @@ void SpikingNet::init() {
         case randomNetwork:
             setRandomNetwork();
             break;
-        case uniformNetwork: // for debug
+        case uniformNetwork:
             setUniformNetwork();
             break;
         case gridNetwork:
             setGridNetwork();
             break;
     }
+}
+
+void SpikingNet::reset() {
+    // delete STP variables
+    delete[] STPu;
+    delete[] STPx;
+    delete[] STPw;
+    STPu = 0;
+    STPx = 0;
+    STPw = 0;
+
+    // delete weights
+    for(int i = 0; i < neuronSize; ++i) {
+        delete[] weights[i];
+        weights[i] = 0;
+    }
+    delete[] weights;
+    weights = 0;
 }
 
 // inhibitory neurons are first, the rest is excitatory neurons
@@ -352,14 +340,42 @@ void SpikingNet::update(double deltaTime) {
     applyFiring();
 }
 
-double sigmoidPositiveUnityClamp(double value) {
+double sigmoid(double value) {
     // https://www.desmos.com/calculator/ikdusaa9yh
     // sigmoid function centered at 0
     // df/dx = 1 at x = 0
     // f(0) = 0
     // f(infinity) = 1
     // f(-infinity) = -1
+
     return 2.0 / (1.0 + exp(- 2.0 * value)) - 1.0;
+}
+
+double softKnee(double value, double window) {
+    // https://www.desmos.com/calculator/34ccgcquj3
+    // soft clip function
+    // is linear in the range [-window, window]
+    // converges towards 1 at infinity
+    // converges towards -1 at -infinity
+    // second derivative is smooth at all points
+
+    if(- window < value && value < window)
+        return value;
+
+    double scalingFactor = 1.0 / (1.0 - window);
+
+    if(value > 0) {
+        return sigmoid(scalingFactor * (value - window)) / scalingFactor + window;
+    } else {
+        return sigmoid(scalingFactor * (value + window)) / scalingFactor - window;
+    }
+}
+
+double softKneePositive(double value, double window) {
+    // indentical to function above except it uses the range [0, 1] instead
+    // the window parameter also behaves diferently: it defines the total size of the linear region
+    // the region [1/2 - window/2, 1/2 + window/2] is linear
+    return (softKnee(2.0 * value - 1.0, window) + 1.0) * 0.5;
 }
 
 void SpikingNet::applyFiring() {
@@ -387,11 +403,11 @@ void SpikingNet::applyFiring() {
             outputGroupSpiking[indexGroup] += 1.0 * averagingConstant;
         }
         // update output group activation data
-        outputGroupActivation[indexGroup] += 100.0 * std::max<double>(0.0, (neurons[index].getV() - neurons[index].getC()) / (neurons[index].getPotentialThreshold() - neurons[index].getC())) * averagingConstant;
+        outputGroupActivation[indexGroup] += (neurons[index].getV() - neurons[index].getC()) / (neurons[index].getPotentialThreshold() - neurons[index].getC()) * averagingConstant;
     }
-    // apply sigmoid on output group activation
+    // apply soft-clamp on output group activation
     for(int i = 0; i < outputGroupSize; i++) {
-        outputGroupActivation[i] = sigmoidPositiveUnityClamp(outputGroupActivation[i]);
+        outputGroupActivation[i] = softKneePositive(outputGroupActivation[i], 0.8);
     }
     if(flagDebug) {
         //std::cout << "number of neurons firing: " << total << endl;
@@ -633,4 +649,175 @@ void SpikingNet::wholeNetworkStimulation(double strength) {
     for(int i = 0; i < neuronSize; ++i) {
             neurons[i].addToI(strength);
     }
+}
+
+// ############################### Qt read / write ###############################
+
+int SpikingNet::getNeuronSize() const {
+    return neuronSize;
+}
+
+double SpikingNet::getTimeScale() const {
+    return this->timeScale;
+}
+
+double SpikingNet::getInhibitoryPortion() const {
+    return this->inhibitoryPortion;
+}
+
+double SpikingNet::getInputPortion() const {
+    return this->inputPortion;
+}
+
+double SpikingNet::getOutputPortion() const {
+    return this->outputPortion;
+}
+
+NeuronType SpikingNet::getInhibitoryNeuronType() const {
+    return this->inhibitoryNeuronType;
+}
+
+NeuronType SpikingNet::getExcitatoryNeuronType() const {
+    return this->excitatoryNeuronType;
+}
+
+double SpikingNet::getInhibitoryNoise() const {
+    return this->inhibitoryNoise;
+}
+
+double SpikingNet::getExcitatoryNoise() const {
+    return this->excitatoryNoise;
+}
+
+bool SpikingNet::getFlagSTP() const {
+    return this->flagSTP;
+}
+
+bool SpikingNet::getFlagSTDP() const {
+    return this->flagSTDP;
+}
+
+bool SpikingNet::getFlagDecay() const {
+    return this->flagDecay;
+}
+
+void SpikingNet::writeNeuronSize(int neuronSize) {
+    if(this->neuronSize == neuronSize)
+        return;
+
+    // reset network, since these parameters only take effect when the network is created anew
+    reset();
+    initialize();
+
+    this->neuronSize = neuronSize;
+    emit neuronSizeChanged(neuronSize);
+}
+
+void SpikingNet::writeTimeScale(double timeScale) {
+    if(this->timeScale == timeScale)
+        return;
+
+    this->timeScale = timeScale;
+    emit timeScaleChanged(timeScale);
+}
+
+void SpikingNet::writeInhibitoryPortion(double inhibitoryPortion) {
+    if(this->inhibitoryPortion == inhibitoryPortion)
+        return;
+
+    // reset network, since these parameters only take effect when the network is created anew
+    // TODO: this isn't as efficient as it could be since it's not necessary to deallocate and reallocate memory for weights / STP
+    reset();
+    initialize();
+
+    this->inhibitoryPortion = inhibitoryPortion;
+    emit inhibitoryPortionChanged(inhibitoryPortion);
+}
+
+void SpikingNet::writeInputPortion(double inputPortion) {
+    if(this->inputPortion == inputPortion)
+        return;
+
+    // update input size
+    inputSize = (neuronSize - inhibitorySize) * inputPortion;
+
+    this->inputPortion = inputPortion;
+    emit inputPortionChanged(inputPortion);
+}
+
+void SpikingNet::writeOutputPortion(double outputPortion) {
+    if(this->outputPortion == outputPortion)
+        return;
+
+    // update output size
+    outputSize = (neuronSize - inhibitorySize) * outputPortion;
+
+    this->outputPortion = outputPortion;
+    emit outputPortionChanged(outputPortion);
+}
+
+void SpikingNet::writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType) {
+    if(this->inhibitoryNeuronType == inhibitoryNeuronType)
+        return;
+
+    // reset network, since these parameters only take effect when the network is created anew
+    // TODO: this isn't as efficient as it could be since it's not necessary to deallocate and reallocate memory for weights / STP
+    reset();
+    initialize();
+
+    this->inhibitoryNeuronType = inhibitoryNeuronType;
+    emit inhibitoryNeuronTypeChanged(inhibitoryNeuronType);
+}
+
+void SpikingNet::writeExcitatoryNeuronType(NeuronType excitatoryNeuronType) {
+    if(this->excitatoryNeuronType == excitatoryNeuronType)
+        return;
+
+    // reset network, since these parameters only take effect when the network is created anew
+    // TODO: this isn't as efficient as it could be since it's not necessary to deallocate and reallocate memory for weights / STP
+    reset();
+    initialize();
+
+    this->excitatoryNeuronType = excitatoryNeuronType;
+    emit excitatoryNeuronTypeChanged(excitatoryNeuronType);
+}
+
+void SpikingNet::writeInhibitoryNoise(double inhibitoryNoise) {
+    if(this->inhibitoryNoise == inhibitoryNoise)
+        return;
+
+    this->inhibitoryNoise = inhibitoryNoise;
+    emit inhibitoryNoiseChanged(inhibitoryNoise);
+}
+
+void SpikingNet::writeExcitatoryNoise(double excitatoryNoise) {
+    if(this->excitatoryNoise == excitatoryNoise)
+        return;
+
+    this->excitatoryNoise = excitatoryNoise;
+    emit excitatoryNoiseChanged(excitatoryNoise);
+}
+
+void SpikingNet::writeFlagSTP(bool flagSTP) {
+    if(this->flagSTP == flagSTP)
+        return;
+
+    this->flagSTP = flagSTP;
+    emit flagSTPChanged(flagSTP);
+}
+
+void SpikingNet::writeFlagSTDP(bool flagSTDP) {
+    if(this->flagSTDP == flagSTDP)
+        return;
+
+    this->flagSTDP = flagSTDP;
+    emit flagSTDPChanged(flagSTDP);
+}
+
+void SpikingNet::writeFlagDecay(bool flagDecay) {
+    if(this->flagDecay == flagDecay)
+        return;
+
+    this->flagDecay = flagDecay;
+    emit flagDecayChanged(flagDecay);
 }

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -516,7 +516,7 @@ void SpikingNet::computeSTDP(double deltaTime) {
                     // another (uniquely different) neuron has fired in the last STDPTau frames (excluding the current frame)
 
                     // this is part of the exponential function described above
-                    d = deltaTimeMillis * (0.1 * pow(0.95, (1000.0 * STDPTimes[j])));
+                    d = deltaTimeMillis * (0.1 * STDPStrength * pow(0.95, (1000.0 * STDPTimes[j])));
 
                     // update the weight from j to i, should be increased since j fired before i.
                     if(weights[j][i] != 0.0) {
@@ -539,7 +539,7 @@ void SpikingNet::computeSTDP(double deltaTime) {
 
 void SpikingNet::computeSTP(double deltaTime) {
     for(int i = inhibitorySize; i < neuronSize; ++i) {
-        STPw[i] = getSTPValue(i, neurons[i].isFiring(), deltaTime);
+        STPw[i] = STPStrength * getSTPValue(i, neurons[i].isFiring(), deltaTime);
     }
 }
 
@@ -689,6 +689,18 @@ double SpikingNet::getExcitatoryNoise() const {
     return this->excitatoryNoise;
 }
 
+double SpikingNet::getSTPStrength() const {
+    return this->STPStrength;
+}
+
+double SpikingNet::getSTDPStrength() const {
+    return this->STDPStrength;
+}
+
+double SpikingNet::getDecayConstant() const {
+    return this->decayConstant;
+}
+
 bool SpikingNet::getFlagSTP() const {
     return this->flagSTP;
 }
@@ -796,6 +808,30 @@ void SpikingNet::writeExcitatoryNoise(double excitatoryNoise) {
 
     this->excitatoryNoise = excitatoryNoise;
     emit excitatoryNoiseChanged(excitatoryNoise);
+}
+
+void SpikingNet::writeSTPStrength(double STPStrength) {
+    if(this->STPStrength == STPStrength)
+        return;
+
+    this->STPStrength = STPStrength;
+    emit STPStrengthChanged(STPStrength);
+}
+
+void SpikingNet::writeSTDPStrength(double STDPStrength) {
+    if(this->STDPStrength == STDPStrength)
+        return;
+
+    this->STDPStrength = STDPStrength;
+    emit STDPStrengthChanged(STDPStrength);
+}
+
+void SpikingNet::writeDecayConstant(double decayConstant) {
+    if(this->decayConstant == decayConstant)
+        return;
+
+    this->decayConstant = decayConstant;
+    emit decayConstantChanged(decayConstant);
 }
 
 void SpikingNet::writeFlagSTP(bool flagSTP) {

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -39,10 +39,7 @@ void SpikingNet::initialize() {
 
     // set random seed
     if(flagRandomDevice) {
-        std::random_device random;
-        int seed = random();
         randomGenerator.seed(random());
-        std::cout << "seed: " << seed << std::endl;
     } else {
         randomGenerator.seed(randomSeed);
     }

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -40,7 +40,9 @@ void SpikingNet::initialize() {
     // set random seed
     if(flagRandomDevice) {
         std::random_device random;
+        int seed = random();
         randomGenerator.seed(random());
+        std::cout << "seed: " << seed << std::endl;
     } else {
         randomGenerator.seed(randomSeed);
     }

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -39,6 +39,7 @@ void SpikingNet::initialize() {
 
     // set random seed
     if(flagRandomDevice) {
+        std::random_device random;
         randomGenerator.seed(random());
     } else {
         randomGenerator.seed(randomSeed);

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -395,7 +395,7 @@ void SpikingNet::applyFiring() {
     }
     if(flagDebug) {
         //std::cout << "number of neurons firing: " << total << endl;
-        std::cout << "activation of group 0: " << outputGroupActivation[0] << endl;
+        //std::cout << "activation of group 0: " << outputGroupActivation[0] << endl;
     }
 }
 

--- a/DynamicLights/SpikingNet.h
+++ b/DynamicLights/SpikingNet.h
@@ -40,6 +40,11 @@ class SpikingNet : public Generator {
     Q_PROPERTY(NeuronType excitatoryNeuronType READ getExcitatoryNeuronType WRITE writeExcitatoryNeuronType NOTIFY excitatoryNeuronTypeChanged)
     Q_PROPERTY(double inhibitoryNoise READ getInhibitoryNoise WRITE writeInhibitoryNoise NOTIFY inhibitoryNoiseChanged)
     Q_PROPERTY(double excitatoryNoise READ getExcitatoryNoise WRITE writeExcitatoryNoise NOTIFY excitatoryNoiseChanged)
+
+    Q_PROPERTY(double STPStrength READ getSTPStrength WRITE writeSTDPStrength NOTIFY STPStrengthChanged)
+    Q_PROPERTY(double STDPStrength READ getSTDPStrength WRITE writeSTDPStrength NOTIFY STDPStrengthChanged)
+    Q_PROPERTY(double decayConstant READ getDecayConstant WRITE writeDecayConstant NOTIFY decayConstantChanged)
+
     Q_PROPERTY(bool flagSTP READ getFlagSTP WRITE writeFlagSTP NOTIFY flagSTPChanged)
     Q_PROPERTY(bool flagSTDP READ getFlagSTDP WRITE writeFlagSTDP NOTIFY flagSTDPChanged)
     Q_PROPERTY(bool flagDecay READ getFlagDecay WRITE writeFlagDecay NOTIFY flagDecayChanged)
@@ -77,6 +82,9 @@ private:
     double      decayConstant = 0.9995;
 
     double      timeScale = 30.0 / 1000.0;
+
+    double STDPStrength = 1.0;
+    double STPStrength = 1.0;
 
     bool        flagSTP                 = false;
     bool        flagSTDP                = true;
@@ -154,6 +162,9 @@ public:
     NeuronType getExcitatoryNeuronType() const;
     double getInhibitoryNoise() const;
     double getExcitatoryNoise() const;
+    double getSTPStrength() const;
+    double getSTDPStrength() const;
+    double getDecayConstant() const;
     bool getFlagSTP() const;
     bool getFlagSTDP() const;
     bool getFlagDecay() const;
@@ -168,6 +179,9 @@ public slots:
     void writeExcitatoryNeuronType(NeuronType excitatoryNeuronType);
     void writeInhibitoryNoise(double inhibitoryNoise);
     void writeExcitatoryNoise(double excitatoryNoise);
+    void writeSTPStrength(double STPStrength);
+    void writeSTDPStrength(double STDPStrength);
+    void writeDecayConstant(double decayConstant);
     void writeFlagSTP(bool flagSTP);
     void writeFlagSTDP(bool flagSTDP);
     void writeFlagDecay(bool flagDecay);
@@ -182,6 +196,9 @@ signals:
     void excitatoryNeuronTypeChanged(NeuronType excitatoryNeuronType);
     void inhibitoryNoiseChanged(double inhibitoryNoise);
     void excitatoryNoiseChanged(double excitatoryNoise);
+    void STPStrengthChanged(double STPStrength);
+    void STDPStrengthChanged(double STDPStrength);
+    void decayConstantChanged(double decayConstant);
     void flagSTPChanged(bool flagSTP);
     void flagSTDPChanged(bool flagSTDP);
     void flagDecayChanged(bool flagDecay);

--- a/DynamicLights/SpikingNet.h
+++ b/DynamicLights/SpikingNet.h
@@ -68,7 +68,7 @@ private:
     bool        flagDecay               = false;
     bool        flagDirectConnection    = true;
     bool        flagRandomDevice        = true;
-    bool        flagDebug               = true;
+    bool        flagDebug               = false;
 
     // the neurons
     std::vector<Izhikevich> neurons;

--- a/DynamicLights/SpikingNet.h
+++ b/DynamicLights/SpikingNet.h
@@ -68,14 +68,16 @@ private:
     bool        flagDecay               = false;
     bool        flagDirectConnection    = true;
     bool        flagRandomDevice        = true;
-    bool        flagDebug               = false;
+    bool        flagDebug               = true;
 
     // the neurons
     std::vector<Izhikevich> neurons;
     // the weights
     double** weights;
     // the per-output group spiking average
-    std::vector<double> outputSpiking;
+    std::vector<double> outputGroupSpiking;
+    // the per-output group activation average
+    std::vector<double> outputGroupActivation;
 
     // STDP
     std::vector<int> STDPTimes;
@@ -96,7 +98,7 @@ private:
     inline void updateNeurons(double deltaTime);
     inline void updateInput();
     inline void updateInputDebug();
-    inline void checkFiring();
+    inline void applyFiring();
     inline void computeSTDP(double deltaTime);
     inline void computeSTP(double deltaTime);
     inline double getSTPValue(int index, bool isFiring, double deltaTime);
@@ -118,7 +120,8 @@ private:
     void wholeStimulation(double strength);
     void wholeNetworkStimulation();
     void wholeNetworkStimulation(double strength);
-    int  getSpikedOutput(int outputGroupIndex);
+    double getOutputGroupSpiking(int outputGroupIndex);
+    double getOutputGroupActivation(int outputGroupIndex);
     
 public:
     SpikingNet();

--- a/DynamicLights/SpikingNet.h
+++ b/DynamicLights/SpikingNet.h
@@ -29,13 +29,28 @@ enum NetworkType {
 };
 
 class SpikingNet : public Generator {
+    // TODO: figure out how we decide to add / remove inputs. this should probably be a property that belongs to the Generator abstract class, rather than this.
+    Q_OBJECT
+    Q_PROPERTY(int neuronSize READ getNeuronSize WRITE writeNeuronSize NOTIFY neuronSizeChanged)
+    Q_PROPERTY(double timeScale READ getTimeScale WRITE writeTimeScale NOTIFY timeScaleChanged)
+    Q_PROPERTY(double inhibitoryPortion READ getInhibitoryPortion WRITE writeInhibitoryPortion NOTIFY inhibitoryPortionChanged)
+    Q_PROPERTY(double inputPortion READ getInputPortion WRITE writeInputPortion NOTIFY inputPortionChanged)
+    Q_PROPERTY(double outputPortion READ getOutputPortion WRITE writeOutputPortion NOTIFY outputPortionChanged)
+    Q_PROPERTY(NeuronType inhibitoryNeuronType READ getInhibitoryNeuronType WRITE writeInhibitoryNeuronType NOTIFY inhibitoryNeuronTypeChanged)
+    Q_PROPERTY(NeuronType excitatoryNeuronType READ getExcitatoryNeuronType WRITE writeExcitatoryNeuronType NOTIFY excitatoryNeuronTypeChanged)
+    Q_PROPERTY(double inhibitoryNoise READ getInhibitoryNoise WRITE writeInhibitoryNoise NOTIFY inhibitoryNoiseChanged)
+    Q_PROPERTY(double excitatoryNoise READ getExcitatoryNoise WRITE writeExcitatoryNoise NOTIFY excitatoryNoiseChanged)
+    Q_PROPERTY(bool flagSTP READ getFlagSTP WRITE writeFlagSTP NOTIFY flagSTPChanged)
+    Q_PROPERTY(bool flagSTDP READ getFlagSTDP WRITE writeFlagSTDP NOTIFY flagSTDPChanged)
+    Q_PROPERTY(bool flagDecay READ getFlagDecay WRITE writeFlagDecay NOTIFY flagDecayChanged)
+
 private:
     NetworkType networkType = gridNetwork;
     int         neuronSize = 1000;
-    int         connectionsPerNeuron = 20;
+    int         connectionsPerNeuron = 20; // this is used in any non-grid network
     int         randomSeed = 0;
     int         gridNetworkWidth = 20;
-    double      gridNetworkConnectionRate = 0.01;
+    double      gridNetworkConnectionRate = 0.01; // this is used in the grid network
 
     double      inhibitoryPortion = 0.2;
     int         inhibitorySize = neuronSize * inhibitoryPortion;
@@ -74,7 +89,6 @@ private:
     std::vector<Izhikevich> neurons;
     // the weights
     double** weights;
-    // the per-output group spiking average
     std::vector<double> outputGroupSpiking;
     // the per-output group activation average
     std::vector<double> outputGroupActivation;
@@ -94,7 +108,7 @@ private:
     inline int indexExcitatoryNeuron(int i);
     inline int indexInputNeuron(int i);
     inline int indexOutputNeuron(int i);
-    
+
     inline void updateNeurons(double deltaTime);
     inline void updateInput();
     inline void updateInputDebug();
@@ -111,7 +125,8 @@ private:
     void setChainNetwork();
     void setGridNetwork();
 
-    void init();
+    void initialize();
+    void reset();
     void update(double deltaTime);
     void stimulation();
     void stimulation(double strength);
@@ -120,12 +135,54 @@ private:
     void wholeStimulation(double strength);
     void wholeNetworkStimulation();
     void wholeNetworkStimulation(double strength);
+
     double getOutputGroupSpiking(int outputGroupIndex);
     double getOutputGroupActivation(int outputGroupIndex);
-    
+
 public:
     SpikingNet();
     ~SpikingNet();
 
     void computeOutput(double deltaTime);
+
+    int getNeuronSize() const;
+    double getTimeScale() const;
+    double getInhibitoryPortion() const;
+    double getInputPortion() const;
+    double getOutputPortion() const;
+    NeuronType getInhibitoryNeuronType() const;
+    NeuronType getExcitatoryNeuronType() const;
+    double getInhibitoryNoise() const;
+    double getExcitatoryNoise() const;
+    bool getFlagSTP() const;
+    bool getFlagSTDP() const;
+    bool getFlagDecay() const;
+
+public slots:
+    void writeNeuronSize(int neuronSize);
+    void writeTimeScale(double timeScale);
+    void writeInhibitoryPortion(double inhibitoryPortion);
+    void writeInputPortion(double inputPortion);
+    void writeOutputPortion(double outputPortion);
+    void writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType);
+    void writeExcitatoryNeuronType(NeuronType excitatoryNeuronType);
+    void writeInhibitoryNoise(double inhibitoryNoise);
+    void writeExcitatoryNoise(double excitatoryNoise);
+    void writeFlagSTP(bool flagSTP);
+    void writeFlagSTDP(bool flagSTDP);
+    void writeFlagDecay(bool flagDecay);
+
+signals:
+    void neuronSizeChanged(int neuronSize);
+    void timeScaleChanged(double timeScale);
+    void inhibitoryPortionChanged(double inhibitoryPortion);
+    void inputPortionChanged(double inputPortion);
+    void outputPortionChanged(double outputPortion);
+    void inhibitoryNeuronTypeChanged(NeuronType inhibitoryNeuronType);
+    void excitatoryNeuronTypeChanged(NeuronType excitatoryNeuronType);
+    void inhibitoryNoiseChanged(double inhibitoryNoise);
+    void excitatoryNoiseChanged(double excitatoryNoise);
+    void flagSTPChanged(bool flagSTP);
+    void flagSTDPChanged(bool flagSTDP);
+    void flagDecayChanged(bool flagDecay);
 };


### PR DESCRIPTION
The output values of the SNN are now normalized in the range [0, 1], and so is the output monitor. This resolves bug #54. At the moment this is calculated as an average of the neuron activations, scaled to their usual activation ranges, with soft-clipping applied afterwards.

No changes were made to the input code as there isn't really a well-defined range of values that neurons expect, and we will want to be able to control the stimulation strength later on. This should probably be added as a new issue. 

Most important parameters of the SNN are now exposed as QProperties, and properties that cause memory re-allocations are handled properly — it is possible to total neuron count on the fly, for example. This implements #25. The following properties are exposed:

* neuronSize (int, neuron count. this causes a model reset)
* timeScale (double, speed of the simulartion, 1 means biologically accurate)
* inhibitoryPortion (double, portion of the network dedicated to inhibitory neurons, ranged [0, 1]. this causes a model reset)
* inputPortion (double, portion of the network dedicated to input neurons, ranged [0, 1]. this causes a model reset)
* outputPortion (double, portion of the network dedicated to input neurons, ranged [0, 1]. this causes a model reset)
* inhibitoryNeuronType (type of neuron used for inhibitory section. types are defined in Izhikevich.cpp. this causes a model reset)
* excitatoryNeuronType (type of neuron used for inhibitory section. types are defined in Izhikevich.cpp. this causes a model reset)
* inhibitoryNoise (double, amount of noise injected into inhibitory neurons)
* excitatoryNoise (double, amount of noise injected into excitatory neurons)
* STPStrength (double, intensity of short term plasticity learning)
* STDPStrength (double, intensity of spike-timing dependent plasticity)
* decayConstant (double, decay rate of weights per second)
* flagSTP (boolean, enables short-term plasticity)
* flagSTDP (boolean, enables spiking-time dependent plasticity)
* flagDecay (boolean, enables decay of connection weights)

This also introduces a small performance improvement to #81. It seemed like there was a typo in the code that connected the Generator signals to the GeneratorModel: the generator at index i would notify all generators from index 0 to i, rather than only the generator at index i.

This also fixes a big, fat, ugly bug in the SNN that went undetected for a long time. The connections between neurons was never initialized in previous versions, and weights would all be set to zero. This seems to fix #78.