### PR TITLE
Create parameters rack and hook most fields to GeneratorModel

### DIFF
--- a/DynamicLights/Fields/AreaField.qml
+++ b/DynamicLights/Fields/AreaField.qml
@@ -53,6 +53,9 @@ Field {
 
                 // mouse interaction
                 selectByMouse: true
+
+                // signal hooks
+                onEditingFinished: valueChanged(text)
             }
 
             ScrollBar.vertical: ScrollBar {}

--- a/DynamicLights/Fields/AreaField.qml
+++ b/DynamicLights/Fields/AreaField.qml
@@ -10,6 +10,8 @@ Field {
     property string placeholder: "Area Field"
     property string defaultText: "Area Field"
 
+    Layout.fillHeight: true
+
     Item {
         Layout.fillWidth: true
         Layout.fillHeight: true

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -8,11 +8,11 @@ ColumnLayout {
     id: field
 
     property string labelText: "Label"
-    property int fieldWidth: 200
+    property int fieldWidth: Stylesheet.field.initialWidth
 
     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-    Layout.preferredWidth: fieldWidth
-    Layout.preferredHeight: fieldLabel.height + 45
+    Layout.maximumWidth: fieldWidth
+    Layout.fillWidth: true
 
     spacing: 5
 

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -10,6 +10,8 @@ ColumnLayout {
     property string labelText: "Label"
     property int fieldWidth: Stylesheet.field.initialWidth
 
+    signal valueChanged(variant newValue)
+
     Layout.alignment: Qt.AlignLeft | Qt.AlignTop
     Layout.maximumWidth: fieldWidth
     Layout.fillWidth: true

--- a/DynamicLights/Fields/FieldFrame.qml
+++ b/DynamicLights/Fields/FieldFrame.qml
@@ -3,7 +3,7 @@ import QtQuick 2.9
 import "../Style"
 
 Item {
-    property int frameWidth: 200
+    property int frameWidth: Stylesheet.field.initialWidth
     property bool isHovered: false
     property bool isFocused: false
 

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -7,8 +7,10 @@ import "../Style"
 Field {
     id: selectField
 
-    property int index: 0
-    property variant options: ["A", "B", "C"]
+    property int index
+    property variant options
+    property variant enumOptions
+    property bool initialized: false
 
     ComboBox {
         id: comboBox
@@ -16,11 +18,16 @@ Field {
         Layout.fillWidth: true
 
         // root settings
-        currentIndex: index
+        currentIndex: selectField.index
         model: options
         font {
             family: Stylesheet.fonts.main
             pixelSize: 18
+        }
+
+        onCurrentIndexChanged: {
+            if (!initialized) return initialized = true;
+            selectField.valueChanged(currentIndex);
         }
 
         // background

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -13,6 +13,8 @@ Field {
     ComboBox {
         id: comboBox
 
+        Layout.fillWidth: true
+
         // root settings
         currentIndex: index
         model: options

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -63,7 +63,7 @@ Field {
                 handle: Rectangle {}
 
                 // signals
-                onValueChanged: currVal = value;
+                onValueChanged: sliderField.valueChanged(value)
             }
 
             TextField {

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -19,7 +19,7 @@ Field {
 
     Item {
         Layout.fillWidth: true
-        height: 40
+        Layout.preferredHeight: 40
 
         // background
         FieldFrame {

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -54,7 +54,7 @@ Field {
         // interactivity
         selectByMouse: true
 
-        // signals
-        onEditingFinished: defaultText = text
+        // signal hooks
+        onEditingFinished: textField.valueChanged(text)
     }
 }

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -9,6 +9,9 @@ Field {
 
     property string placeholder: ""
     property string defaultText: "Text Field"
+    property bool validateInt: false
+
+    IntValidator { id: validator }
 
     TextField {
         id: fieldInput
@@ -19,8 +22,7 @@ Field {
         height: 40
 
         // text
-        text: defaultText
-
+        text: activeFocus ? defaultText : metrics.elidedText
         placeholderText: placeholder
 
         // font + color
@@ -30,6 +32,15 @@ Field {
         }
         color: Stylesheet.colors.white
 
+        // text metrics (used to elide text)
+        TextMetrics {
+            id: metrics
+            font: fieldInput.font
+            text: textField.defaultText
+            elide: Text.ElideRight
+            elideWidth: fieldInput.width
+        }
+
         // background
         background: FieldFrame {
             isHovered: fieldInput.hovered
@@ -38,8 +49,12 @@ Field {
 
         // TODO: add validator
         // eg. no empty values allowed flag as widget property
+        validator: validateInt ? validator : null
 
         // interactivity
         selectByMouse: true
+
+        // signals
+        onEditingFinished: defaultText = text
     }
 }

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -24,7 +24,7 @@ class Generator : public QObject
     Q_OBJECT
     Q_PROPERTY(QString name READ getName WRITE writeName NOTIFY nameChanged)
     Q_PROPERTY(QString type READ getType NOTIFY typeChanged)
-    Q_PROPERTY(QString description READ getDescription NOTIFY descriptionChanged)
+    Q_PROPERTY(QString description READ getDescription WRITE writeDescription NOTIFY descriptionChanged)
     Q_PROPERTY(double outputMonitor READ getOutputMonitor NOTIFY outputMonitorChanged)
 protected:
     // the generator class provides input and output buffers

--- a/DynamicLights/GeneratorModel.cpp
+++ b/DynamicLights/GeneratorModel.cpp
@@ -5,9 +5,18 @@ GeneratorModel::GeneratorModel(QList<QSharedPointer<Generator>> generators) {
     this->generators = generators;
 
     for(int i = 0; i < generators.count(); i++) {
+        // update model every time the output monitor is computed
         connect(generators[i].get(), &Generator::outputMonitorChanged, this, [=]() {
             emit dataChanged(index(i), index(i), { OutputMonitorRole });
         });
+
+        // update model when name is changed in GenRack (per-generator action)
+        connect(generators[i].get(), &Generator::nameChanged, this, [=]() {
+            emit dataChanged(index(i), index(i), { NameRole });
+        });
+
+        // these are the only two properties that need to force update the model's data
+        // since they are always relayed to a ListView
     }
 }
 
@@ -55,4 +64,10 @@ QHash<int, QByteArray> GeneratorModel::roleNames() const {
         roles[DescriptionRole] = "description";
         roles[OutputMonitorRole] = "outputMonitor";
         return roles;
-};
+}
+
+Generator * GeneratorModel::at(int index)
+{
+    if (index < 0) return nullptr;
+    return generators[index].get();
+}

--- a/DynamicLights/GeneratorModel.h
+++ b/DynamicLights/GeneratorModel.h
@@ -40,6 +40,8 @@ public:
     void populate();
     QHash<int, QByteArray> roleNames() const;
 
+    Q_INVOKABLE Generator * at(int index);
+
 private:
     QList<QSharedPointer<Generator>> generators;
 };

--- a/DynamicLights/GeneratorWidget.qml
+++ b/DynamicLights/GeneratorWidget.qml
@@ -8,12 +8,6 @@ import "./Style"
  * Widget to control a generator.
  */
 Button {
-    property int generatorIndex: 0
-    property string generatorName: "Default Name"
-    property string generatorType: "Default Type"
-    property string generatorDescription: "Default description"
-    property double generatorOutputMonitor: 0.0
-
     // state props
     property bool selected: false
 
@@ -83,7 +77,7 @@ Button {
             id: outputIndicator
 
             luminosity: model.outputMonitor
-            lightColor: Stylesheet.colors.outputs[generatorIndex % Stylesheet.colors.outputs.length]
+            lightColor: Stylesheet.colors.outputs[model.index % Stylesheet.colors.outputs.length]
 
             Layout.rightMargin: 10
             Layout.alignment: Qt.AlignRight

--- a/DynamicLights/GeneratorWidget.qml
+++ b/DynamicLights/GeneratorWidget.qml
@@ -53,7 +53,7 @@ Button {
         Label {
             id: labelIndex
 
-            text: generatorIndex + 1
+            text: model.index + 1
             color: Stylesheet.colors.white
             font {
                 family: Stylesheet.fonts.main
@@ -68,7 +68,7 @@ Button {
             id: labelName
 
             Layout.leftMargin: 30
-            text: generatorName
+            text: model.name
             color: selected ? Stylesheet.colors.black : Stylesheet.colors.white
             font {
                 family: Stylesheet.fonts.main
@@ -82,12 +82,22 @@ Button {
         OutputIndicator {
             id: outputIndicator
 
-            luminosity: generatorOutputMonitor
+            luminosity: model.outputMonitor
             lightColor: Stylesheet.colors.outputs[generatorIndex % Stylesheet.colors.outputs.length]
 
             Layout.rightMargin: 10
             Layout.alignment: Qt.AlignRight
         }
+    }
+
+    // inferior border
+    Rectangle {
+        id: borderBottom
+        width: parent.width
+        height: 1
+        anchors.bottom: parent.bottom
+        color: Stylesheet.colors.white
+        opacity: 0.1
     }
 
     onClicked: selected = !selected

--- a/DynamicLights/Racks/GenRack.qml
+++ b/DynamicLights/Racks/GenRack.qml
@@ -1,6 +1,8 @@
 import QtQuick 2.9
 import QtQuick.Layouts 1.3
+
 import "../Fields"
+import "../Style"
 
 Rack {
     id: genRack
@@ -8,13 +10,14 @@ Rack {
     rackName: "GEN"
     removable: false
 
-    content: RowLayout {
+    RowLayout {
         Layout.fillWidth: true
-
-        spacing: 30
+        Layout.margins: Stylesheet.field.spacing
+        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+        spacing: Stylesheet.field.spacing
 
         ColumnLayout {
-            spacing: 30
+            spacing: parent.spacing
 
             TextField {
                 labelText: "Name"
@@ -29,15 +32,16 @@ Rack {
         }
 
         AreaField {
+            Layout.fillHeight: true
             labelText: "Description"
             placeholder: "Enter description here"
             defaultText: "This is a description for the Spiking Neural Network (SNN) generator. This algorithm creates short peaks generatively over time."
 
-            fieldWidth: 400
+            fieldWidth: (Stylesheet.field.initialWidth * 2) + Stylesheet.field.spacing
         }
 
         ColumnLayout {
-            spacing: 30
+            spacing: parent.spacing
 
             SliderField {
                 labelText: "Ratio"
@@ -53,7 +57,11 @@ Rack {
                 step: 1
             }
         }
-
-
     }
 }
+
+/*##^##
+Designer {
+    D{i:0;autoSize:true;height:480;width:640}
+}
+##^##*/

--- a/DynamicLights/Racks/GenRack.qml
+++ b/DynamicLights/Racks/GenRack.qml
@@ -39,24 +39,6 @@ Rack {
 
             fieldWidth: (Stylesheet.field.initialWidth * 2) + Stylesheet.field.spacing
         }
-
-        ColumnLayout {
-            spacing: parent.spacing
-
-            SliderField {
-                labelText: "Ratio"
-                step: 0.05
-                exponent: 2.0
-            }
-
-            SliderField {
-                labelText: "Ratio 2"
-                minVal: 10
-                maxVal: 110
-                currVal: 20
-                step: 1
-            }
-        }
     }
 }
 

--- a/DynamicLights/Racks/GenRack.qml
+++ b/DynamicLights/Racks/GenRack.qml
@@ -22,12 +22,17 @@ Rack {
             TextField {
                 labelText: "Name"
                 placeholder: "Name"
-                defaultText: "Spiking Neural Network"
+
+                // TODO: softcode this
+                // ("softcode" loosely defined here as the opposite of "hardcode")
+                defaultText: genID < 0 ? "" : generatorModel.at(genID).name
+                onValueChanged: generatorModel.at(genID).name = newValue
             }
 
             SelectField {
                 labelText: "Type"
                 options: ["SNN"]
+                // TODO: link Generator property
             }
         }
 
@@ -35,7 +40,9 @@ Rack {
             Layout.fillHeight: true
             labelText: "Description"
             placeholder: "Enter description here"
-            defaultText: "This is a description for the Spiking Neural Network (SNN) generator. This algorithm creates short peaks generatively over time."
+
+            defaultText: genID < 0 ? "" : generatorModel.at(genID).description
+            onValueChanged: generatorModel.at(genID).description = newValue
 
             fieldWidth: (Stylesheet.field.initialWidth * 2) + Stylesheet.field.spacing
         }

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -24,22 +24,30 @@ Rack {
             TextField {
                 validateInt: true
                 labelText: "Neurons"
-                defaultText: "300"
+
+                defaultText: genID < 0 ? "" : generatorModel.at(genID).neuronSize
+                onValueChanged: generatorModel.at(genID).neuronSize = newValue
             }
 
             SelectField {
                 labelText: "Network type"
+
                 options: ["Random", "Sparse", "Grid", "Uniform"]
+                index: 2
             }
 
             SelectField {
                 labelText: "Inh. neuron type"
+
                 options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+                // index: genID < 0 ? 0 : generatorModel.at(genID).inhibitoryNeuronType
             }
 
             SelectField {
                 labelText: "Exc. neuron type"
+
                 options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+                // index: genID < 0 ? 0 : generatorModel.at(genID).excitatoryNeuronType
             }
         }
 
@@ -49,14 +57,23 @@ Rack {
 
             SliderField {
                 labelText: "Inh. portion"
+
+                currVal: genID < 0 ? 0 : generatorModel.at(genID).inhibitoryPortion
+                onValueChanged: generatorModel.at(genID).inhibitoryPortion = newValue
             }
 
             SliderField {
                 labelText: "Input portion"
+
+                currVal: genID < 0 ? 0 : generatorModel.at(genID).inputPortion
+                onValueChanged: generatorModel.at(genID).inputPortion = newValue
             }
 
             SliderField {
                 labelText: "Output portion"
+
+                currVal: genID < 0 ? 0 : generatorModel.at(genID).outputPortion
+                onValueChanged: generatorModel.at(genID).outputPortion = newValue
             }
         }
     }

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -5,6 +5,8 @@ import QtQuick.Layouts 1.3
 import "../Fields"
 import "../Style"
 
+import com.dynamiclights 1.0
+
 Rack {
     id: paramsRack
 
@@ -25,29 +27,35 @@ Rack {
                 validateInt: true
                 labelText: "Neurons"
 
-                defaultText: genID < 0 ? "" : generatorModel.at(genID).neuronSize
+                defaultText: generatorModel.at(genID).neuronSize
                 onValueChanged: generatorModel.at(genID).neuronSize = newValue
             }
 
             SelectField {
                 labelText: "Network type"
 
-                options: ["Random", "Sparse", "Grid", "Uniform"]
-                index: 2
+                options: ["Random", "Sparse", "Uniform", "Grid"]
+                // TODO: make singletons for these
+                enumOptions: [
+                    SpikingNet.RandomNetwork,
+                    SpikingNet.SparseNetwork,
+                    SpikingNet.UniformNetwork,
+                    SpikingNet.GridNetwork
+                ]
+                index: generatorModel.at(genID).networkType
+                onValueChanged: generatorModel.at(genID).networkType = enumOptions[newValue]
             }
 
             SelectField {
                 labelText: "Inh. neuron type"
 
                 options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
-                // index: genID < 0 ? 0 : generatorModel.at(genID).inhibitoryNeuronType
             }
 
             SelectField {
                 labelText: "Exc. neuron type"
 
                 options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
-                // index: genID < 0 ? 0 : generatorModel.at(genID).excitatoryNeuronType
             }
         }
 

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -11,31 +11,53 @@ Rack {
     rackName: "PARAMS"
     removable: false
 
-    RowLayout {
+    ColumnLayout {
         Layout.fillWidth: true
         Layout.margins: Stylesheet.field.spacing
         Layout.alignment: Qt.AlignLeft | Qt.AlignTop
         spacing: Stylesheet.field.spacing
 
-        TextField {
-            validateInt: true
-            labelText: "Neurons"
-            defaultText: "300"
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Stylesheet.field.spacing
+
+            TextField {
+                validateInt: true
+                labelText: "Neurons"
+                defaultText: "300"
+            }
+
+            SelectField {
+                labelText: "Network type"
+                options: ["Random", "Sparse", "Grid", "Uniform"]
+            }
+
+            SelectField {
+                labelText: "Inh. neuron type"
+                options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+            }
+
+            SelectField {
+                labelText: "Exc. neuron type"
+                options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+            }
         }
 
-        SelectField {
-            labelText: "Network type"
-            options: ["Random", "Sparse", "Grid", "Uniform"]
-        }
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Stylesheet.field.spacing
 
-        SelectField {
-            labelText: "Inh. neuron type"
-            options: ["Spiking", "Spiking (rand)", "Resonator", "Resonator (rand)", "Chattering"]
-        }
+            SliderField {
+                labelText: "Inh. portion"
+            }
 
-        SelectField {
-            labelText: "Exc. neuron type"
-            options: ["Spiking", "Spiking (rand)", "Resonator", "Resonator (rand)", "Chattering"]
+            SliderField {
+                labelText: "Input portion"
+            }
+
+            SliderField {
+                labelText: "Output portion"
+            }
         }
     }
 }

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -1,0 +1,41 @@
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
+
+import "../Fields"
+import "../Style"
+
+Rack {
+    id: paramsRack
+
+    rackName: "PARAMS"
+    removable: false
+
+    RowLayout {
+        Layout.fillWidth: true
+        Layout.margins: Stylesheet.field.spacing
+        Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+        spacing: Stylesheet.field.spacing
+
+        TextField {
+            validateInt: true
+            labelText: "Neurons"
+            defaultText: "300"
+        }
+
+        SelectField {
+            labelText: "Network type"
+            options: ["Random", "Sparse", "Grid", "Uniform"]
+        }
+
+        SelectField {
+            labelText: "Inh. neuron type"
+            options: ["Spiking", "Spiking (rand)", "Resonator", "Resonator (rand)", "Chattering"]
+        }
+
+        SelectField {
+            labelText: "Exc. neuron type"
+            options: ["Spiking", "Spiking (rand)", "Resonator", "Resonator (rand)", "Chattering"]
+        }
+    }
+}

--- a/DynamicLights/Racks/Rack.qml
+++ b/DynamicLights/Racks/Rack.qml
@@ -16,10 +16,8 @@ ColumnLayout {
     property bool collapsed: false
     property bool removable: true
 
-    // components
-    property alias content: contentLoader.sourceComponent
-
     Layout.fillWidth: true
+    Layout.maximumHeight: 245
     spacing: 0
 
     // top label
@@ -52,29 +50,5 @@ ColumnLayout {
         //Button { id: btnCollapse }
     }
 
-    // content (todo)
-    Item {
-        Layout.fillWidth: true
-
-        Rectangle {
-            anchors.fill: parent
-            color: "#212121"
-            border.width: 0
-        }
-
-        RowLayout {
-            anchors.leftMargin: 20
-            anchors.bottomMargin: 40
-            anchors.rightMargin: 20
-            anchors.topMargin: 40
-            anchors.fill: parent
-            spacing: 0
-
-            Layout.alignment: Qt.AlignLeft | Qt.AlignTop
-
-            // field content
-            Loader { id: contentLoader }
-        }
-    }
-
+    // content (extended)
 }

--- a/DynamicLights/Racks/Rack.qml
+++ b/DynamicLights/Racks/Rack.qml
@@ -20,6 +20,8 @@ ColumnLayout {
     Layout.maximumHeight: 245
     spacing: 0
 
+    visible: genID > -1
+
     // top label
     RowLayout {
         Layout.fillWidth: true

--- a/DynamicLights/Racks/Rack.qml
+++ b/DynamicLights/Racks/Rack.qml
@@ -18,9 +18,8 @@ ColumnLayout {
 
     Layout.fillWidth: true
     Layout.maximumHeight: 245
+    Layout.alignment: Qt.AlignLeft | Qt.AlignTop
     spacing: 0
-
-    visible: genID > -1
 
     // top label
     RowLayout {

--- a/DynamicLights/Racks/RackView.qml
+++ b/DynamicLights/Racks/RackView.qml
@@ -14,10 +14,11 @@ import "../"
 ColumnLayout {
     id: rackView
 
-    property int genID: -1
+    property int genID: item.genID
 
     Layout.fillWidth: true
     Layout.alignment: Qt.AlignTop | Qt.AlignLeft
+    spacing: 0
 
     GenRack { genID: rackView.genID; }
     ParamsRack { genID: rackView.genID; }

--- a/DynamicLights/Racks/RackView.qml
+++ b/DynamicLights/Racks/RackView.qml
@@ -12,16 +12,13 @@ import QtQuick.Layouts 1.0
 import "../"
 
 ColumnLayout {
+    id: rackView
+
     property int genID: -1
 
     Layout.fillWidth: true
     Layout.alignment: Qt.AlignTop | Qt.AlignLeft
 
-    GenRack {
-        genID: genID
-    }
-
-    ParamsRack {
-        genID: genID
-    }
+    GenRack { genID: rackView.genID; }
+    ParamsRack { genID: rackView.genID; }
 }

--- a/DynamicLights/Racks/RackView.qml
+++ b/DynamicLights/Racks/RackView.qml
@@ -15,10 +15,13 @@ ColumnLayout {
     property int genID: -1
 
     Layout.fillWidth: true
-    Layout.fillHeight: true
     Layout.alignment: Qt.AlignTop | Qt.AlignLeft
 
     GenRack {
+        genID: genID
+    }
+
+    ParamsRack {
         genID: genID
     }
 }

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -92,16 +92,16 @@ void SpikingNet::initialize() {
 
     // set network type
     switch(networkType) {
-        case sparseNetwork:
+        case NetworkType::SparseNetwork:
             setSparseNetwork();
             break;
-        case randomNetwork:
+        case NetworkType::RandomNetwork:
             setRandomNetwork();
             break;
-        case uniformNetwork:
+        case NetworkType::UniformNetwork:
             setUniformNetwork();
             break;
-        case gridNetwork:
+        case NetworkType::GridNetwork:
             setGridNetwork();
             break;
     }
@@ -653,6 +653,10 @@ void SpikingNet::wholeNetworkStimulation(double strength) {
 
 // ############################### Qt read / write ###############################
 
+SpikingNet::NetworkType SpikingNet::getNetworkType() const {
+    return networkType;
+}
+
 int SpikingNet::getNeuronSize() const {
     return neuronSize;
 }
@@ -711,6 +715,19 @@ bool SpikingNet::getFlagSTDP() const {
 
 bool SpikingNet::getFlagDecay() const {
     return this->flagDecay;
+}
+
+void SpikingNet::writeNetworkType(SpikingNet::NetworkType networkType) {
+    if (this->networkType == networkType)
+        return;
+
+    // reset network, since these parameters only take effect when the network is created anew
+    // note from Julien: shouldn't the network be reinitialized AFTER changing the values?
+    reset();
+    initialize();
+
+    this->networkType = networkType;
+    emit networkTypeChanged(networkType);
 }
 
 void SpikingNet::writeNeuronSize(int neuronSize) {

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -722,11 +722,12 @@ void SpikingNet::writeNetworkType(SpikingNet::NetworkType networkType) {
         return;
 
     // reset network, since these parameters only take effect when the network is created anew
-    // note from Julien: shouldn't the network be reinitialized AFTER changing the values?
     reset();
-    initialize();
-
+    // do the change
     this->networkType = networkType;
+    // re-initialize
+    initialize();
+    // signal
     emit networkTypeChanged(networkType);
 }
 
@@ -736,9 +737,11 @@ void SpikingNet::writeNeuronSize(int neuronSize) {
 
     // reset network, since these parameters only take effect when the network is created anew
     reset();
-    initialize();
-
+    // do the change
     this->neuronSize = neuronSize;
+    // re-initialize
+    initialize();
+    // signal
     emit neuronSizeChanged(neuronSize);
 }
 
@@ -757,9 +760,11 @@ void SpikingNet::writeInhibitoryPortion(double inhibitoryPortion) {
     // reset network, since these parameters only take effect when the network is created anew
     // TODO: this isn't as efficient as it could be since it's not necessary to deallocate and reallocate memory for weights / STP
     reset();
-    initialize();
-
+    // do the change
     this->inhibitoryPortion = inhibitoryPortion;
+    // re-initialize
+    initialize();
+    // signal
     emit inhibitoryPortionChanged(inhibitoryPortion);
 }
 
@@ -792,9 +797,11 @@ void SpikingNet::writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType) {
     // reset network, since these parameters only take effect when the network is created anew
     // TODO: this isn't as efficient as it could be since it's not necessary to deallocate and reallocate memory for weights / STP
     reset();
-    initialize();
-
+    // do the change
     this->inhibitoryNeuronType = inhibitoryNeuronType;
+    // re-initialize
+    initialize();
+    // signal
     emit inhibitoryNeuronTypeChanged(inhibitoryNeuronType);
 }
 
@@ -805,9 +812,11 @@ void SpikingNet::writeExcitatoryNeuronType(NeuronType excitatoryNeuronType) {
     // reset network, since these parameters only take effect when the network is created anew
     // TODO: this isn't as efficient as it could be since it's not necessary to deallocate and reallocate memory for weights / STP
     reset();
-    initialize();
-
+    // do the change
     this->excitatoryNeuronType = excitatoryNeuronType;
+    // re-initialize
+    initialize();
+    // signal
     emit excitatoryNeuronTypeChanged(excitatoryNeuronType);
 }
 

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -725,8 +725,6 @@ void SpikingNet::writeNeuronSize(int neuronSize) {
     initialize();
     // signal
     emit neuronSizeChanged(neuronSize);
-
-    std::cout << "writeNeuronSize" << std::endl;
 }
 
 void SpikingNet::writeTimeScale(double timeScale) {
@@ -735,8 +733,6 @@ void SpikingNet::writeTimeScale(double timeScale) {
 
     this->timeScale = timeScale;
     emit timeScaleChanged(timeScale);
-
-    std::cout << "writeTimeScale" << std::endl;
 }
 
 void SpikingNet::writeInhibitoryPortion(double inhibitoryPortion) {
@@ -752,8 +748,6 @@ void SpikingNet::writeInhibitoryPortion(double inhibitoryPortion) {
     initialize();
     // signal
     emit inhibitoryPortionChanged(inhibitoryPortion);
-
-    std::cout << "writeInhibitoryPortion" << std::endl;
 }
 
 void SpikingNet::writeInputPortion(double inputPortion) {
@@ -765,8 +759,6 @@ void SpikingNet::writeInputPortion(double inputPortion) {
 
     this->inputPortion = inputPortion;
     emit inputPortionChanged(inputPortion);
-
-    std::cout << "writeInputPortion" << std::endl;
 }
 
 void SpikingNet::writeOutputPortion(double outputPortion) {
@@ -778,8 +770,6 @@ void SpikingNet::writeOutputPortion(double outputPortion) {
 
     this->outputPortion = outputPortion;
     emit outputPortionChanged(outputPortion);
-
-    std::cout << "writeOutputPortion" << std::endl;
 }
 
 void SpikingNet::writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType) {
@@ -795,8 +785,6 @@ void SpikingNet::writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType) {
     initialize();
     // signal
     emit inhibitoryNeuronTypeChanged(inhibitoryNeuronType);
-
-    std::cout << "writeInhibitoryNeuronType" << std::endl;
 }
 
 void SpikingNet::writeExcitatoryNeuronType(NeuronType excitatoryNeuronType) {
@@ -812,8 +800,6 @@ void SpikingNet::writeExcitatoryNeuronType(NeuronType excitatoryNeuronType) {
     initialize();
     // signal
     emit excitatoryNeuronTypeChanged(excitatoryNeuronType);
-
-    std::cout << "writeExcitatoryNeuronType" << std::endl;
 }
 
 void SpikingNet::writeInhibitoryNoise(double inhibitoryNoise) {
@@ -822,8 +808,6 @@ void SpikingNet::writeInhibitoryNoise(double inhibitoryNoise) {
 
     this->inhibitoryNoise = inhibitoryNoise;
     emit inhibitoryNoiseChanged(inhibitoryNoise);
-
-    std::cout << "writeInhibitoryNoise" << std::endl;
 }
 
 void SpikingNet::writeExcitatoryNoise(double excitatoryNoise) {
@@ -832,8 +816,6 @@ void SpikingNet::writeExcitatoryNoise(double excitatoryNoise) {
 
     this->excitatoryNoise = excitatoryNoise;
     emit excitatoryNoiseChanged(excitatoryNoise);
-
-    std::cout << "writeExcitatoryNoise" << std::endl;
 }
 
 void SpikingNet::writeSTPStrength(double STPStrength) {
@@ -842,8 +824,6 @@ void SpikingNet::writeSTPStrength(double STPStrength) {
 
     this->STPStrength = STPStrength;
     emit STPStrengthChanged(STPStrength);
-
-    std::cout << "writeSTPStrength" << std::endl;
 }
 
 void SpikingNet::writeSTDPStrength(double STDPStrength) {
@@ -852,8 +832,6 @@ void SpikingNet::writeSTDPStrength(double STDPStrength) {
 
     this->STDPStrength = STDPStrength;
     emit STDPStrengthChanged(STDPStrength);
-
-    std::cout << "writeSTDPStrength" << std::endl;
 }
 
 void SpikingNet::writeDecayConstant(double decayConstant) {
@@ -862,8 +840,6 @@ void SpikingNet::writeDecayConstant(double decayConstant) {
 
     this->decayConstant = decayConstant;
     emit decayConstantChanged(decayConstant);
-
-    std::cout << "writeDecayConstant" << std::endl;
 }
 
 void SpikingNet::writeFlagSTP(bool flagSTP) {
@@ -872,8 +848,6 @@ void SpikingNet::writeFlagSTP(bool flagSTP) {
 
     this->flagSTP = flagSTP;
     emit flagSTPChanged(flagSTP);
-
-    std::cout << "writeFlagSTP" << std::endl;
 }
 
 void SpikingNet::writeFlagSTDP(bool flagSTDP) {
@@ -882,8 +856,6 @@ void SpikingNet::writeFlagSTDP(bool flagSTDP) {
 
     this->flagSTDP = flagSTDP;
     emit flagSTDPChanged(flagSTDP);
-
-    std::cout << "writeFlagSTDP" << std::endl;
 }
 
 void SpikingNet::writeFlagDecay(bool flagDecay) {
@@ -892,6 +864,4 @@ void SpikingNet::writeFlagDecay(bool flagDecay) {
 
     this->flagDecay = flagDecay;
     emit flagDecayChanged(flagDecay);
-
-    std::cout << "writeFlagDecay" << std::endl;
 }

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -729,6 +729,8 @@ void SpikingNet::writeNetworkType(SpikingNet::NetworkType networkType) {
     initialize();
     // signal
     emit networkTypeChanged(networkType);
+
+    std::cout << "writeNetworkType" << std::endl;
 }
 
 void SpikingNet::writeNeuronSize(int neuronSize) {
@@ -743,6 +745,8 @@ void SpikingNet::writeNeuronSize(int neuronSize) {
     initialize();
     // signal
     emit neuronSizeChanged(neuronSize);
+
+    std::cout << "writeNeuronSize" << std::endl;
 }
 
 void SpikingNet::writeTimeScale(double timeScale) {
@@ -751,6 +755,8 @@ void SpikingNet::writeTimeScale(double timeScale) {
 
     this->timeScale = timeScale;
     emit timeScaleChanged(timeScale);
+
+    std::cout << "writeTimeScale" << std::endl;
 }
 
 void SpikingNet::writeInhibitoryPortion(double inhibitoryPortion) {
@@ -766,6 +772,8 @@ void SpikingNet::writeInhibitoryPortion(double inhibitoryPortion) {
     initialize();
     // signal
     emit inhibitoryPortionChanged(inhibitoryPortion);
+
+    std::cout << "writeInhibitoryPortion" << std::endl;
 }
 
 void SpikingNet::writeInputPortion(double inputPortion) {
@@ -777,6 +785,8 @@ void SpikingNet::writeInputPortion(double inputPortion) {
 
     this->inputPortion = inputPortion;
     emit inputPortionChanged(inputPortion);
+
+    std::cout << "writeInputPortion" << std::endl;
 }
 
 void SpikingNet::writeOutputPortion(double outputPortion) {
@@ -788,6 +798,8 @@ void SpikingNet::writeOutputPortion(double outputPortion) {
 
     this->outputPortion = outputPortion;
     emit outputPortionChanged(outputPortion);
+
+    std::cout << "writeOutputPortion" << std::endl;
 }
 
 void SpikingNet::writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType) {
@@ -803,6 +815,8 @@ void SpikingNet::writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType) {
     initialize();
     // signal
     emit inhibitoryNeuronTypeChanged(inhibitoryNeuronType);
+
+    std::cout << "writeInhibitoryNeuronType" << std::endl;
 }
 
 void SpikingNet::writeExcitatoryNeuronType(NeuronType excitatoryNeuronType) {
@@ -818,6 +832,8 @@ void SpikingNet::writeExcitatoryNeuronType(NeuronType excitatoryNeuronType) {
     initialize();
     // signal
     emit excitatoryNeuronTypeChanged(excitatoryNeuronType);
+
+    std::cout << "writeExcitatoryNeuronType" << std::endl;
 }
 
 void SpikingNet::writeInhibitoryNoise(double inhibitoryNoise) {
@@ -826,6 +842,8 @@ void SpikingNet::writeInhibitoryNoise(double inhibitoryNoise) {
 
     this->inhibitoryNoise = inhibitoryNoise;
     emit inhibitoryNoiseChanged(inhibitoryNoise);
+
+    std::cout << "writeInhibitoryNoise" << std::endl;
 }
 
 void SpikingNet::writeExcitatoryNoise(double excitatoryNoise) {
@@ -834,6 +852,8 @@ void SpikingNet::writeExcitatoryNoise(double excitatoryNoise) {
 
     this->excitatoryNoise = excitatoryNoise;
     emit excitatoryNoiseChanged(excitatoryNoise);
+
+    std::cout << "writeExcitatoryNoise" << std::endl;
 }
 
 void SpikingNet::writeSTPStrength(double STPStrength) {
@@ -842,6 +862,8 @@ void SpikingNet::writeSTPStrength(double STPStrength) {
 
     this->STPStrength = STPStrength;
     emit STPStrengthChanged(STPStrength);
+
+    std::cout << "writeSTPStrength" << std::endl;
 }
 
 void SpikingNet::writeSTDPStrength(double STDPStrength) {
@@ -850,6 +872,8 @@ void SpikingNet::writeSTDPStrength(double STDPStrength) {
 
     this->STDPStrength = STDPStrength;
     emit STDPStrengthChanged(STDPStrength);
+
+    std::cout << "writeSTDPStrength" << std::endl;
 }
 
 void SpikingNet::writeDecayConstant(double decayConstant) {
@@ -858,6 +882,8 @@ void SpikingNet::writeDecayConstant(double decayConstant) {
 
     this->decayConstant = decayConstant;
     emit decayConstantChanged(decayConstant);
+
+    std::cout << "writeDecayConstant" << std::endl;
 }
 
 void SpikingNet::writeFlagSTP(bool flagSTP) {
@@ -866,6 +892,8 @@ void SpikingNet::writeFlagSTP(bool flagSTP) {
 
     this->flagSTP = flagSTP;
     emit flagSTPChanged(flagSTP);
+
+    std::cout << "writeFlagSTP" << std::endl;
 }
 
 void SpikingNet::writeFlagSTDP(bool flagSTDP) {
@@ -874,6 +902,8 @@ void SpikingNet::writeFlagSTDP(bool flagSTDP) {
 
     this->flagSTDP = flagSTDP;
     emit flagSTDPChanged(flagSTDP);
+
+    std::cout << "writeFlagSTDP" << std::endl;
 }
 
 void SpikingNet::writeFlagDecay(bool flagDecay) {
@@ -882,4 +912,6 @@ void SpikingNet::writeFlagDecay(bool flagDecay) {
 
     this->flagDecay = flagDecay;
     emit flagDecayChanged(flagDecay);
+
+    std::cout << "writeFlagDecay" << std::endl;
 }

--- a/DynamicLights/SpikingNet.h
+++ b/DynamicLights/SpikingNet.h
@@ -21,16 +21,10 @@
 #include <random>
 #include <vector>
 
-enum NetworkType {
-    randomNetwork,
-    sparseNetwork,
-    uniformNetwork,
-    gridNetwork
-};
-
 class SpikingNet : public Generator {
     // TODO: figure out how we decide to add / remove inputs. this should probably be a property that belongs to the Generator abstract class, rather than this.
     Q_OBJECT
+    Q_PROPERTY(NetworkType networkType READ getNetworkType WRITE writeNetworkType NOTIFY networkTypeChanged)
     Q_PROPERTY(int neuronSize READ getNeuronSize WRITE writeNeuronSize NOTIFY neuronSizeChanged)
     Q_PROPERTY(double timeScale READ getTimeScale WRITE writeTimeScale NOTIFY timeScaleChanged)
     Q_PROPERTY(double inhibitoryPortion READ getInhibitoryPortion WRITE writeInhibitoryPortion NOTIFY inhibitoryPortionChanged)
@@ -49,8 +43,18 @@ class SpikingNet : public Generator {
     Q_PROPERTY(bool flagSTDP READ getFlagSTDP WRITE writeFlagSTDP NOTIFY flagSTDPChanged)
     Q_PROPERTY(bool flagDecay READ getFlagDecay WRITE writeFlagDecay NOTIFY flagDecayChanged)
 
+// enum
+public:
+    enum class NetworkType {
+        RandomNetwork,
+        SparseNetwork,
+        UniformNetwork,
+        GridNetwork
+    };
+    Q_ENUM(NetworkType)
+
 private:
-    NetworkType networkType = gridNetwork;
+    NetworkType networkType = NetworkType::GridNetwork;
     int         neuronSize = 1000;
     int         connectionsPerNeuron = 20; // this is used in any non-grid network
     int         randomSeed = 0;
@@ -153,6 +157,7 @@ public:
 
     void computeOutput(double deltaTime);
 
+    NetworkType getNetworkType() const;
     int getNeuronSize() const;
     double getTimeScale() const;
     double getInhibitoryPortion() const;
@@ -170,6 +175,7 @@ public:
     bool getFlagDecay() const;
 
 public slots:
+    void writeNetworkType(NetworkType networkType);
     void writeNeuronSize(int neuronSize);
     void writeTimeScale(double timeScale);
     void writeInhibitoryPortion(double inhibitoryPortion);
@@ -187,6 +193,7 @@ public slots:
     void writeFlagDecay(bool flagDecay);
 
 signals:
+    void networkTypeChanged(NetworkType networkType);
     void neuronSizeChanged(int neuronSize);
     void timeScaleChanged(double timeScale);
     void inhibitoryPortionChanged(double inhibitoryPortion);

--- a/DynamicLights/Style/Stylesheet.qml
+++ b/DynamicLights/Style/Stylesheet.qml
@@ -29,6 +29,8 @@ QtObject {
     // SPACINGS
     property QtObject field: QtObject {
         readonly property int padding: 8
+        readonly property int initialWidth: 180
+        readonly property int spacing: 30
     }
 
     // TOOLS

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -74,6 +74,11 @@ int main(int argc, char *argv[])
     OscReceiver oscReceiver(receiveOscPort);
     OscSender oscSender(sendOscHost, sendOscPort);
 
+    // make Generator virtual class recognizable to QML
+    // this line is apparently necessary for the QML engine to receive Generator pointers
+    // and retrieve a class instance's exposed properties by model index through said pointer
+    qmlRegisterUncreatableType<Generator>("Generator", 1, 0, "Generator", "Cannot create Generator.");
+
     // create generator list
     QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet());
     QList<QSharedPointer<Generator>> generators = {spikingNet};

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -77,7 +77,8 @@ int main(int argc, char *argv[])
     // make Generator virtual class recognizable to QML
     // this line is apparently necessary for the QML engine to receive Generator pointers
     // and retrieve a class instance's exposed properties by model index through said pointer
-    qmlRegisterUncreatableType<Generator>("Generator", 1, 0, "Generator", "Cannot create Generator.");
+    qmlRegisterUncreatableType<Generator>("com.dynamiclights", 1, 0, "Generator", "Cannot instanciate Generator.");
+    qmlRegisterUncreatableType<SpikingNet>("com.dynamiclights", 1, 0, "SpikingNet", "Cannot instanciate SpikingNet.");
 
     // create generator list
     QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet());

--- a/DynamicLights/main.qml
+++ b/DynamicLights/main.qml
@@ -84,20 +84,25 @@ ApplicationWindow {
         spacing: 0
 
         // List of generators
-        ListView {
-            orientation: Qt.Vertical
+        Item {
             Layout.preferredWidth: parent.width * 0.25
             Layout.minimumWidth: 200
+            Layout.maximumWidth: 400
             Layout.fillHeight: true
-            model: generatorModel
 
-            delegate: GeneratorWidget {
-                generatorName: name
-                generatorType: type
-                generatorDescription: description
-                generatorOutputMonitor: outputMonitor
-                generatorIndex: index
+            Rectangle {
+                color: Stylesheet.colors.black
+                anchors.fill: parent
             }
+
+            ListView {
+                anchors.fill: parent
+                orientation: Qt.Vertical
+                model: generatorModel
+                delegate: GeneratorWidget {}
+            }
+
+            // TODO: new generator button here
         }
 
         // List of racks for currently selected generator

--- a/DynamicLights/main.qml
+++ b/DynamicLights/main.qml
@@ -13,6 +13,7 @@ ApplicationWindow {
     id: window
 
     property string lastMessageReceived: ""
+    property int activeGeneratorIndex: -1
 
     visible: true
     width: 1280
@@ -99,7 +100,9 @@ ApplicationWindow {
                 anchors.fill: parent
                 orientation: Qt.Vertical
                 model: generatorModel
-                delegate: GeneratorWidget {}
+                delegate: GeneratorWidget {
+                    onClicked: window.activeGeneratorIndex = model.index
+                }
             }
 
             // TODO: new generator button here
@@ -108,6 +111,7 @@ ApplicationWindow {
         // List of racks for currently selected generator
         RackView {
             id: rackView
+            genID: activeGeneratorIndex
         }
     }
 }

--- a/DynamicLights/main.qml
+++ b/DynamicLights/main.qml
@@ -108,10 +108,15 @@ ApplicationWindow {
             // TODO: new generator button here
         }
 
-        // List of racks for currently selected generator
-        RackView {
-            id: rackView
-            genID: activeGeneratorIndex
+        // list of racks for currently selected generator
+        Loader {
+            id: rackViewLoader
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignLeft | Qt.AlignTop
+
+            property int genID: activeGeneratorIndex
+
+            source: genID < 0 ? "" : "Racks/RackView.qml"
         }
     }
 }

--- a/DynamicLights/qml.qrc
+++ b/DynamicLights/qml.qrc
@@ -23,6 +23,7 @@
         <file>Style/qmldir</file>
         <file>Style/Stylesheet.qml</file>
         <file>Racks/GenRack.qml</file>
+        <file>Racks/ParamsRack.qml</file>
         <file>Racks/Rack.qml</file>
         <file>Racks/RackView.qml</file>
     </qresource>


### PR DESCRIPTION
This PR adds many new functionalities to the application:
- The `ParamsRack.qml` component was created, which delegates the active generator's mutable parameters as a way for the user to interact with them. Currently, all fields are hardcoded specifically for the SNN architecture, some parameters of which (mostly flags) are missing, since the toggle component hasn't been properly designed yet.
- Most fields made available to the user are successfully hooked to the model and its items, and update consequently when edited by the user. The majority of SelectFields (with the exception of "Network type", for testing purposes) still don't affect the model, but will be once we find a better way to expose a `Generator`'s virtual properties to QML.
- The `RackView` component is now fully loaded in respects to the active generator's index, ie. whether or not the user has selected a generator to work with.
- General layout and field management tweaks were also applied to streamline QML integration.