### PR TITLE
Link remaining SNN props to the backend

### DIFF
--- a/DynamicLights/DynamicLights.pro
+++ b/DynamicLights/DynamicLights.pro
@@ -60,6 +60,7 @@ HEADERS += \
     Generator.h \
     GeneratorModel.h \
     Izhikevich.h \
+    NeuronType.h \
     SpikingNet.h
 
 INCLUDEPATH += $$PWD/../qosc

--- a/DynamicLights/Fields/AreaField.qml
+++ b/DynamicLights/Fields/AreaField.qml
@@ -45,11 +45,7 @@ Field {
                 background: Rectangle { opacity: 0 }
 
                 // font & color
-                font {
-                    family: Stylesheet.fonts.main
-                    pixelSize: 14
-                }
-                color: Stylesheet.colors.white
+                font.pixelSize: 14
 
                 // mouse interaction
                 selectByMouse: true

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -25,7 +25,8 @@ ColumnLayout {
         text: labelText
         font {
             family: Stylesheet.fonts.sub
-            pixelSize: 14
+            pixelSize: 13
+            letterSpacing: 13 * 0.05
             capitalization: Font.AllUppercase
         }
     }

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -23,7 +23,6 @@ ColumnLayout {
         id: fieldLabel
 
         text: labelText
-        color: Stylesheet.colors.white
         font {
             family: Stylesheet.fonts.sub
             pixelSize: 14

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -9,8 +9,6 @@ Field {
 
     property int index
     property variant options
-    property variant enumOptions
-    property bool initialized: false
 
     ComboBox {
         id: comboBox
@@ -21,10 +19,7 @@ Field {
         currentIndex: selectField.index
         model: options
 
-        onCurrentIndexChanged: {
-            if (!initialized) return initialized = true;
-            selectField.valueChanged(currentIndex);
-        }
+        onCurrentIndexChanged: selectField.valueChanged(currentIndex)
 
         // background
         background: FieldFrame {
@@ -68,13 +63,15 @@ Field {
             id: cbPopup
             y: comboBox.height
             width: comboBox.width
-            height: contentHeight
+            height: contentItem.implicitHeight < 240 ? contentItem.implicitHeight : 240
             padding: 0
 
             contentItem: ListView {
-                id: popupList
+                clip: true
                 implicitHeight: contentHeight
                 model: comboBox.popup.visible ? comboBox.delegateModel : null
+
+                ScrollIndicator.vertical: ScrollIndicator {}
             }
 
             background: Rectangle {

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -21,7 +21,6 @@ Field {
         currentIndex: selectField.index
         model: options
         font {
-            family: Stylesheet.fonts.main
             pixelSize: 18
         }
 
@@ -45,17 +44,16 @@ Field {
             // item contents
             contentItem: Text {
                 text: modelData
-                color: Stylesheet.colors.white
                 opacity: hovered ? 1 : 0.5
                 font.family: comboBox.font.family
                 font.pixelSize: 14
+                color: Stylesheet.colors.white
                 padding: Stylesheet.field.padding
             }
 
             // item background
             background: Rectangle {
                 anchors.fill: parent
-                color: Stylesheet.colors.white
                 opacity: hovered ? 0.1 : 0
                 border.width: 0
             }
@@ -66,8 +64,6 @@ Field {
             text: comboBox.displayText
             verticalAlignment: Text.AlignVCenter
             height: 40
-
-            color: Stylesheet.colors.white
         }
 
         // popup

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -20,9 +20,6 @@ Field {
         // root settings
         currentIndex: selectField.index
         model: options
-        font {
-            pixelSize: 18
-        }
 
         onCurrentIndexChanged: {
             if (!initialized) return initialized = true;

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -65,6 +65,7 @@ Field {
                         width: parent.width * slider.visualPosition
                         anchors.left: parent.left
                         height: parent.height
+                        // TODO: change 0 to generator index
                         color: Stylesheet.colors.outputs[0]
                     }
                 }
@@ -96,12 +97,10 @@ Field {
 
                 // font and color
                 font {
-                    family: Stylesheet.fonts.main
                     weight: Font.Bold
                     pixelSize: 16
                 }
                 background: Rectangle { opacity: 0 }
-                color: Stylesheet.colors.white
 
                 // signals
                 onEditingFinished: {

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -119,7 +119,7 @@ Field {
             // text
             text: parseValue(slider.value)
             horizontalAlignment: Text.AlignHCenter
-            validator: RegExpValidator { regExp: /\d*.*\d*/ }
+            validator: DoubleValidator { bottom: minVal; top: maxVal }
             selectByMouse: true
 
             background: Rectangle { opacity: 0 }

--- a/DynamicLights/Fields/SwitchField.qml
+++ b/DynamicLights/Fields/SwitchField.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+
+Item {
+
+}

--- a/DynamicLights/Fields/SwitchField.qml
+++ b/DynamicLights/Fields/SwitchField.qml
@@ -1,5 +1,58 @@
-import QtQuick 2.0
+import QtQuick 2.9
+import QtQuick.Controls 2.2
+import QtQuick.Layouts 1.3
 
-Item {
+import "../Style"
 
+Field {
+    id: switchField
+
+    property bool on: false
+
+    spacing: 10
+
+    Switch {
+        id: switchObj
+
+        indicator: Rectangle {
+            id: indicatorBg
+            implicitWidth: 55
+            implicitHeight: 30
+            radius: implicitHeight / 2
+            color: Stylesheet.colors.black
+
+            Rectangle {
+                id: indicator
+                width: 20; height: 20
+                x: 5; y: 5
+                radius: width / 2
+                color: "#4C4C4C"
+            }
+        }
+
+        states: State {
+            name: "checked"; when: switchObj.checked
+            PropertyChanges {
+                target: indicator
+                x: indicatorBg.implicitWidth - indicator.width - 5
+                // TODO: change 0 to generator index
+                color: Stylesheet.colors.outputs[0]
+            }
+        }
+
+        transitions: Transition {
+            NumberAnimation {
+                target: indicator
+                property: "x"
+                duration: 350
+                easing.type: Easing.OutQuad
+            }
+
+            ColorAnimation {
+                target: indicator
+                duration: 350
+                easing.type: Easing.OutQuad
+            }
+        }
+    }
 }

--- a/DynamicLights/Fields/SwitchField.qml
+++ b/DynamicLights/Fields/SwitchField.qml
@@ -9,10 +9,14 @@ Field {
 
     property bool on: false
 
-    spacing: 10
+    spacing: 5
+    Layout.fillWidth: false
 
     Switch {
         id: switchObj
+
+        checked: switchField.on
+        onToggled: switchField.valueChanged(checked)
 
         indicator: Rectangle {
             id: indicatorBg

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -25,11 +25,6 @@ Field {
         text: activeFocus ? defaultText : metrics.elidedText
         placeholderText: placeholder
 
-        // font + color
-        font {
-            pixelSize: 18
-        }
-
         // text metrics (used to elide text)
         TextMetrics {
             id: metrics

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -9,9 +9,13 @@ Field {
 
     property string placeholder: ""
     property string defaultText: "Text Field"
-    property bool validateInt: false
 
-    IntValidator { id: validator }
+    // for number fields only
+    // TODO: NumberField with increment/decrement arrows
+    property bool validateInt: false
+    property bool unsigned: false
+
+    IntValidator { id: validator; bottom: unsigned ? 0 : -2147483647 }
 
     TextField {
         id: fieldInput

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -27,10 +27,8 @@ Field {
 
         // font + color
         font {
-            family: Stylesheet.fonts.main
             pixelSize: 18
         }
-        color: Stylesheet.colors.white
 
         // text metrics (used to elide text)
         TextMetrics {

--- a/DynamicLights/Izhikevich.cpp
+++ b/DynamicLights/Izhikevich.cpp
@@ -22,7 +22,7 @@ Izhikevich::Izhikevich() {
     firing = false;
     
     //set param as default Ne.
-    setNeuronType(spikingNeuronRandomized);
+    setNeuronType(NeuronType::SpikingNeuronRandomized);
     u = b * v;
     I = 0.;
     potentialThreshold = 20.;
@@ -31,7 +31,7 @@ Izhikevich::Izhikevich() {
 Izhikevich::~Izhikevich() {
 }
 
-void Izhikevich::setParam(NeuronType type, double a, double b, double c, double d, double u, double v, double I) {
+void Izhikevich::setParam(NeuronType::Enum type, double a, double b, double c, double d, double u, double v, double I) {
     this->type = type;
     this->a = a;
     this->b = b;
@@ -42,17 +42,17 @@ void Izhikevich::setParam(NeuronType type, double a, double b, double c, double 
     this->I = I;
 }
 
-void Izhikevich::setNeuronType(NeuronType type) {
+void Izhikevich::setNeuronType(NeuronType::Enum type) {
     this->type = type;
     switch(type) {
-        case spikingNeuron: {
+        case NeuronType::SpikingNeuron: {
             a = 0.02;
             b = 0.2;
             c = -65.;
             d = 8.;
             break;
         }
-        case spikingNeuronRandomized: {
+        case NeuronType::SpikingNeuronRandomized: {
             std::mt19937 randomGenerator;
             std::uniform_real_distribution<> randomUniform(0.0, 1.0);
             double random = randomUniform(randomGenerator);
@@ -62,14 +62,14 @@ void Izhikevich::setNeuronType(NeuronType type) {
             d = 8. - 6.* random * random;
             break;
         }
-        case resonatorNeuron: {
+        case NeuronType::ResonatorNeuron: {
             a = 0.1;
             b = 0.2;
             c = -65.;
             d = 2.;
             break;
         }
-        case resonatorNeuronRandomized: {
+        case NeuronType::ResonatorNeuronRandomized: {
             std::mt19937 randomGenerator;
             std::uniform_real_distribution<> randomUniform(0.0, 1.0);
             double random = randomUniform(randomGenerator);
@@ -79,21 +79,21 @@ void Izhikevich::setNeuronType(NeuronType type) {
             d = 2.;
             break;
         }
-        case chatteringNeuron: {
+        case NeuronType::ChatteringNeuron: {
             a = 0.02;
             b = 0.2;
             c = -50.;
             d = 2.;
             break;
         }
-        case inhibitoryNeuron: {
+        case NeuronType::InhibitoryNeuron: {
             a = 0.1;
             b = 0.2;
             c = -65.;
             d = 2.;
             break;
         }
-        case inhibitoryNeuronRandomized: {
+        case NeuronType::InhibitoryNeuronRandomized: {
             std::mt19937 randomGenerator;
             std::uniform_real_distribution<> randomUniform(0.0, 1.0);
             double random = randomUniform(randomGenerator);
@@ -103,14 +103,14 @@ void Izhikevich::setNeuronType(NeuronType type) {
             d = 2.;
             break;
         }
-        case excitatoryNeuron : {
+        case NeuronType::ExcitatoryNeuron : {
             a = 0.02;
             b = 0.2;
             c = -50.;
             d = 2.;
             break;
         }
-        case excitatoryNeuronRandomized : {
+        case NeuronType::ExcitatoryNeuronRandomized : {
             std::mt19937 randomGenerator;
             std::uniform_real_distribution<> randomUniform(0.0, 1.0);
             double random = randomUniform(randomGenerator);
@@ -146,7 +146,7 @@ bool Izhikevich::applyFiring() {
     return(firing);
 }
 
-NeuronType Izhikevich::getNeuronType() {
+NeuronType::Enum Izhikevich::getNeuronType() {
     return(type);
 }
 

--- a/DynamicLights/Izhikevich.h
+++ b/DynamicLights/Izhikevich.h
@@ -18,24 +18,14 @@
 #include <iostream>
 #include <vector>
 
-enum NeuronType {
-    spikingNeuron,
-    spikingNeuronRandomized,
-    resonatorNeuron,
-    resonatorNeuronRandomized,
-    chatteringNeuron,
-    inhibitoryNeuron,
-    inhibitoryNeuronRandomized,
-    excitatoryNeuron,
-    excitatoryNeuronRandomized
-};
+#include <NeuronType.h>
 
 class Izhikevich {
 private:
     double potentialThreshold;
     double u;
     double v;
-    NeuronType type;
+    NeuronType::Enum type;
     double I;
     double a, b, c, d;
 
@@ -44,10 +34,10 @@ public:
     ~Izhikevich();
 
     void update(double deltaTime);
-    void setParam(NeuronType type, double a, double b, double c, double d, double u, double v, double I);
-    void setNeuronType(NeuronType type);
+    void setParam(NeuronType::Enum type, double a, double b, double c, double d, double u, double v, double I);
+    void setNeuronType(NeuronType::Enum type);
     bool applyFiring(); // checks if the neuron is firing and updates the differential equationa accordingly
-    NeuronType getNeuronType();
+    NeuronType::Enum getNeuronType();
     bool isFiring();
     
     void setA(double a){ this->a = a; };

--- a/DynamicLights/NeuronType.h
+++ b/DynamicLights/NeuronType.h
@@ -1,12 +1,25 @@
-#ifndef NEURONTYPE_H
-#define NEURONTYPE_H
+// Copyright 2020, Atsushi Masumori & Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
 
 #include <QObject>
 
 class NeuronType : public QObject {
     Q_OBJECT
     Q_ENUMS(Enum);
-
 public:
     enum Enum {
         SpikingNeuron,
@@ -20,8 +33,5 @@ public:
         ExcitatoryNeuronRandomized
     };
 
-    explicit NeuronType(QObject *parent = 0) : QObject(parent) {
-    }
+    explicit NeuronType(QObject *parent = 0) : QObject(parent) {}
 };
-
-#endif // NEURONTYPE_H

--- a/DynamicLights/NeuronType.h
+++ b/DynamicLights/NeuronType.h
@@ -1,0 +1,4 @@
+#ifndef NEURONTYPE_H
+#define NEURONTYPE_H
+
+#endif // NEURONTYPE_H

--- a/DynamicLights/NeuronType.h
+++ b/DynamicLights/NeuronType.h
@@ -1,4 +1,27 @@
 #ifndef NEURONTYPE_H
 #define NEURONTYPE_H
 
+#include <QObject>
+
+class NeuronType : public QObject {
+    Q_OBJECT
+    Q_ENUMS(Enum);
+
+public:
+    enum Enum {
+        SpikingNeuron,
+        SpikingNeuronRandomized,
+        ResonatorNeuron,
+        ResonatorNeuronRandomized,
+        ChatteringNeuron,
+        InhibitoryNeuron,
+        InhibitoryNeuronRandomized,
+        ExcitatoryNeuron,
+        ExcitatoryNeuronRandomized
+    };
+
+    explicit NeuronType(QObject *parent = 0) : QObject(parent) {
+    }
+};
+
 #endif // NEURONTYPE_H

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -5,6 +5,8 @@ import QtQuick.Layouts 1.3
 import "../Fields"
 import "../Style"
 
+import ca.hexagram.xmodal.dynamiclight 1.0
+
 Rack {
     id: paramsRack
 
@@ -79,6 +81,9 @@ Rack {
                 labelText: "Inh. neuron type"
 
                 options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+
+                index: genID < 0 ? 0 : generatorModel.at(genID).inhibitoryNeuronType
+                onValueChanged: generatorModel.at(genID).inhibitoryNeuronType = newValue
             }
 
             SliderField {
@@ -96,6 +101,9 @@ Rack {
                 labelText: "Exc. neuron type"
 
                 options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+
+                index: genID < 0 ? 0 : generatorModel.at(genID).excitatoryNeuronType
+                onValueChanged: generatorModel.at(genID).excitatoryNeuronType = newValue
             }
 
             SliderField {

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -17,6 +17,7 @@ Rack {
         Layout.alignment: Qt.AlignLeft | Qt.AlignTop
         spacing: Stylesheet.field.spacing
 
+        // --= BASIC =--
         RowLayout {
             Layout.fillWidth: true
             spacing: Stylesheet.field.spacing
@@ -29,34 +30,13 @@ Rack {
                 onValueChanged: generatorModel.at(genID).neuronSize = newValue
             }
 
-//            SelectField {
-//                labelText: "Network type"
+            SliderField {
+                labelText: "Time scale"
 
-//                options: ["Random", "Sparse", "Uniform", "Grid"]
-//                // TODO: make singletons for these
-//                enumOptions: [
-//                    SpikingNet.RandomNetwork,
-//                    SpikingNet.SparseNetwork,
-//                    SpikingNet.UniformNetwork,
-//                    SpikingNet.GridNetwork
-//                ]
-//                index: generatorModel.at(genID).networkType
-//                onValueChanged: generatorModel.at(genID).networkType = enumOptions[newValue]
-//            }
-
-            SelectField {
-                labelText: "Inh. neuron type"
-
-                options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
-            }
-
-            SelectField {
-                labelText: "Exc. neuron type"
-
-                options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+                currVal: genID < 0 ? 0 : generatorModel.at(genID).timeScale
+                onValueChanged: generatorModel.at(genID).timeScale = newValue
             }
         }
-
         RowLayout {
             Layout.fillWidth: true
             spacing: Stylesheet.field.spacing
@@ -87,9 +67,108 @@ Rack {
                 currVal: genID < 0 ? 0 : generatorModel.at(genID).outputPortion
                 onValueChanged: generatorModel.at(genID).outputPortion = newValue
             }
+        }
 
-            SwitchField {
-                labelText: "STDP"
+        // --= NEURON BEHAVIOR =--
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Stylesheet.field.spacing
+
+            SelectField {
+                labelText: "Inh. neuron type"
+
+                options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+            }
+
+            SliderField {
+                labelText: "Inh. neuron noise"
+
+                minVal: 1.0
+                maxVal: 20.0
+                updateLag: 70
+
+                currVal: genID < 0 ? 0 : generatorModel.at(genID).inhibitoryNoise
+                onValueChanged: generatorModel.at(genID).inhibitoryNoise = newValue
+            }
+
+            SelectField {
+                labelText: "Exc. neuron type"
+
+                options: ["Spiking", "Spiking (rand.)", "Resonator", "Resonator (rand.)", "Chattering"]
+            }
+
+            SliderField {
+                labelText: "Exc. neuron noise"
+
+                minVal: 1.0
+                maxVal: 20.0
+                updateLag: 70
+
+                currVal: genID < 0 ? 0 : generatorModel.at(genID).excitatoryNoise
+                onValueChanged: generatorModel.at(genID).excitatoryNoise = newValue
+            }
+        }
+
+        // --= FLAGS =--
+        RowLayout {
+            Layout.fillWidth: true
+            spacing: Stylesheet.field.spacing
+
+            ColumnLayout {
+                spacing: 0
+
+                SwitchField {
+                    labelText: "STP"
+
+                    on: genID < 0 ? 0 : generatorModel.at(genID).flagSTP
+                    onValueChanged: generatorModel.at(genID).flagSTP = newValue
+                }
+
+                SliderField {
+                    labelText: "STP strength"
+                    updateLag: 70
+
+                    currVal: genID < 0 ? 0 : generatorModel.at(genID).STPStrength
+                    onValueChanged: generatorModel.at(genID).STPStrength = newValue
+                }
+            }
+
+            ColumnLayout {
+                spacing: 0
+
+                SwitchField {
+                    labelText: "STDP"
+
+                    on: genID < 0 ? 0 : generatorModel.at(genID).flagSTDP
+                    onValueChanged: generatorModel.at(genID).flagSTDP = newValue
+                }
+
+                SliderField {
+                    labelText: "STDP strength"
+                    updateLag: 70
+
+                    currVal: genID < 0 ? 0 : generatorModel.at(genID).STDPStrength
+                    onValueChanged: generatorModel.at(genID).STDPStrength = newValue
+                }
+            }
+
+            ColumnLayout {
+                spacing: 5
+
+                SwitchField {
+                    labelText: "Decay"
+
+                    on: genID < 0 ? 0 : generatorModel.at(genID).flagDecay
+                    onValueChanged: generatorModel.at(genID).flagDecay = newValue
+                }
+
+                SliderField {
+                    labelText: "Decay constant"
+                    updateLag: 70
+
+                    currVal: genID < 0 ? 0 : generatorModel.at(genID).decayConstant
+                    onValueChanged: generatorModel.at(genID).decayConstant = newValue
+                }
             }
         }
     }

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -5,8 +5,6 @@ import QtQuick.Layouts 1.3
 import "../Fields"
 import "../Style"
 
-import com.dynamiclights 1.0
-
 Rack {
     id: paramsRack
 
@@ -88,6 +86,10 @@ Rack {
 
                 currVal: genID < 0 ? 0 : generatorModel.at(genID).outputPortion
                 onValueChanged: generatorModel.at(genID).outputPortion = newValue
+            }
+
+            SwitchField {
+                labelText: "STDP"
             }
         }
     }

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -24,6 +24,7 @@ Rack {
 
             TextField {
                 validateInt: true
+                unsigned: true
                 labelText: "Neurons"
 
                 defaultText: generatorModel.at(genID).neuronSize

--- a/DynamicLights/Racks/Rack.qml
+++ b/DynamicLights/Racks/Rack.qml
@@ -34,7 +34,6 @@ ColumnLayout {
             topPadding: 10
             Layout.fillWidth: true
 
-            color: Stylesheet.colors.white
             font {
                 family: Stylesheet.fonts.sub
                 pixelSize: 16

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -673,11 +673,11 @@ double SpikingNet::getOutputPortion() const {
     return this->outputPortion;
 }
 
-NeuronType SpikingNet::getInhibitoryNeuronType() const {
+NeuronType::Enum SpikingNet::getInhibitoryNeuronType() const {
     return this->inhibitoryNeuronType;
 }
 
-NeuronType SpikingNet::getExcitatoryNeuronType() const {
+NeuronType::Enum SpikingNet::getExcitatoryNeuronType() const {
     return this->excitatoryNeuronType;
 }
 
@@ -772,7 +772,7 @@ void SpikingNet::writeOutputPortion(double outputPortion) {
     emit outputPortionChanged(outputPortion);
 }
 
-void SpikingNet::writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType) {
+void SpikingNet::writeInhibitoryNeuronType(NeuronType::Enum inhibitoryNeuronType) {
     if(this->inhibitoryNeuronType == inhibitoryNeuronType)
         return;
 
@@ -787,7 +787,7 @@ void SpikingNet::writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType) {
     emit inhibitoryNeuronTypeChanged(inhibitoryNeuronType);
 }
 
-void SpikingNet::writeExcitatoryNeuronType(NeuronType excitatoryNeuronType) {
+void SpikingNet::writeExcitatoryNeuronType(NeuronType::Enum excitatoryNeuronType) {
     if(this->excitatoryNeuronType == excitatoryNeuronType)
         return;
 

--- a/DynamicLights/SpikingNet.h
+++ b/DynamicLights/SpikingNet.h
@@ -29,8 +29,8 @@ class SpikingNet : public Generator {
     Q_PROPERTY(double inhibitoryPortion READ getInhibitoryPortion WRITE writeInhibitoryPortion NOTIFY inhibitoryPortionChanged)
     Q_PROPERTY(double inputPortion READ getInputPortion WRITE writeInputPortion NOTIFY inputPortionChanged)
     Q_PROPERTY(double outputPortion READ getOutputPortion WRITE writeOutputPortion NOTIFY outputPortionChanged)
-    Q_PROPERTY(NeuronType inhibitoryNeuronType READ getInhibitoryNeuronType WRITE writeInhibitoryNeuronType NOTIFY inhibitoryNeuronTypeChanged)
-    Q_PROPERTY(NeuronType excitatoryNeuronType READ getExcitatoryNeuronType WRITE writeExcitatoryNeuronType NOTIFY excitatoryNeuronTypeChanged)
+    Q_PROPERTY(NeuronType::Enum inhibitoryNeuronType READ getInhibitoryNeuronType WRITE writeInhibitoryNeuronType NOTIFY inhibitoryNeuronTypeChanged)
+    Q_PROPERTY(NeuronType::Enum excitatoryNeuronType READ getExcitatoryNeuronType WRITE writeExcitatoryNeuronType NOTIFY excitatoryNeuronTypeChanged)
     Q_PROPERTY(double inhibitoryNoise READ getInhibitoryNoise WRITE writeInhibitoryNoise NOTIFY inhibitoryNoiseChanged)
     Q_PROPERTY(double excitatoryNoise READ getExcitatoryNoise WRITE writeExcitatoryNoise NOTIFY excitatoryNoiseChanged)
 
@@ -51,6 +51,7 @@ public:
         GridNetwork
     };
     Q_ENUM(NetworkType)
+    //Q_ENUM(NeuronType)
 
 private:
     NetworkType networkType = NetworkType::GridNetwork;
@@ -62,11 +63,11 @@ private:
 
     double      inhibitoryPortion = 0.2;
     int         inhibitorySize = neuronSize * inhibitoryPortion;
-    NeuronType  inhibitoryNeuronType = chatteringNeuron;
+    NeuronType::Enum  inhibitoryNeuronType = NeuronType::ChatteringNeuron;
     double      inhibitoryInitWeight = -5.0;
     double      inhibitoryNoise = 3.0;
 
-    NeuronType  excitatoryNeuronType = chatteringNeuron;
+    NeuronType::Enum  excitatoryNeuronType = NeuronType::ChatteringNeuron;
     double      excitatoryInitWeight = 15.0;
     double      excitatoryNoise = 5.0;
 
@@ -161,8 +162,8 @@ public:
     double getInhibitoryPortion() const;
     double getInputPortion() const;
     double getOutputPortion() const;
-    NeuronType getInhibitoryNeuronType() const;
-    NeuronType getExcitatoryNeuronType() const;
+    NeuronType::Enum getInhibitoryNeuronType() const;
+    NeuronType::Enum getExcitatoryNeuronType() const;
     double getInhibitoryNoise() const;
     double getExcitatoryNoise() const;
     double getSTPStrength() const;
@@ -178,8 +179,8 @@ public slots:
     void writeInhibitoryPortion(double inhibitoryPortion);
     void writeInputPortion(double inputPortion);
     void writeOutputPortion(double outputPortion);
-    void writeInhibitoryNeuronType(NeuronType inhibitoryNeuronType);
-    void writeExcitatoryNeuronType(NeuronType excitatoryNeuronType);
+    void writeInhibitoryNeuronType(NeuronType::Enum inhibitoryNeuronType);
+    void writeExcitatoryNeuronType(NeuronType::Enum excitatoryNeuronType);
     void writeInhibitoryNoise(double inhibitoryNoise);
     void writeExcitatoryNoise(double excitatoryNoise);
     void writeSTPStrength(double STPStrength);
@@ -195,8 +196,8 @@ signals:
     void inhibitoryPortionChanged(double inhibitoryPortion);
     void inputPortionChanged(double inputPortion);
     void outputPortionChanged(double outputPortion);
-    void inhibitoryNeuronTypeChanged(NeuronType inhibitoryNeuronType);
-    void excitatoryNeuronTypeChanged(NeuronType excitatoryNeuronType);
+    void inhibitoryNeuronTypeChanged(NeuronType::Enum inhibitoryNeuronType);
+    void excitatoryNeuronTypeChanged(NeuronType::Enum excitatoryNeuronType);
     void inhibitoryNoiseChanged(double inhibitoryNoise);
     void excitatoryNoiseChanged(double excitatoryNoise);
     void STPStrengthChanged(double STPStrength);

--- a/DynamicLights/generators/snn/NeuronType.qml
+++ b/DynamicLights/generators/snn/NeuronType.qml
@@ -1,0 +1,5 @@
+import QtQuick 2.0
+
+Item {
+
+}

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -77,8 +77,9 @@ int main(int argc, char *argv[])
     // make Generator virtual class recognizable to QML
     // this line is apparently necessary for the QML engine to receive Generator pointers
     // and retrieve a class instance's exposed properties by model index through said pointer
-    qmlRegisterUncreatableType<Generator>("com.dynamiclights", 1, 0, "Generator", "Cannot instanciate Generator.");
-    qmlRegisterUncreatableType<SpikingNet>("com.dynamiclights", 1, 0, "SpikingNet", "Cannot instanciate SpikingNet.");
+    qmlRegisterUncreatableType<Generator>("ca.hexagram.xmodal.dynamiclight", 1, 0, "Generator", "Cannot instanciate Generator.");
+    qmlRegisterUncreatableType<SpikingNet>("ca.hexagram.xmodal.dynamiclight", 1, 0, "SpikingNet", "Cannot instanciate SpikingNet.");
+    qmlRegisterUncreatableType<NeuronType>("ca.hexagram.xmodal.dynamiclight", 1, 0, "NeuronType", "Cannot instanciate NeuronType.");
 
     // create generator list
     QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet());

--- a/DynamicLights/qml.qrc
+++ b/DynamicLights/qml.qrc
@@ -19,6 +19,7 @@
         <file>Fields/FieldFrame.qml</file>
         <file>Fields/SelectField.qml</file>
         <file>Fields/SliderField.qml</file>
+        <file>Fields/SwitchField.qml</file>
         <file>Fields/TextField.qml</file>
         <file>Style/qmldir</file>
         <file>Style/Stylesheet.qml</file>

--- a/DynamicLights/qtquickcontrols2.conf
+++ b/DynamicLights/qtquickcontrols2.conf
@@ -14,5 +14,6 @@
 
 [Default]
 Font\Family=Overpass
+Font\PixelSize=18
 Palette\WindowText=#ECECEC
 Palette\Text=#ECECEC

--- a/DynamicLights/qtquickcontrols2.conf
+++ b/DynamicLights/qtquickcontrols2.conf
@@ -11,3 +11,8 @@
 ; Primary=Grey
 ; Foreground=White
 ; Background=Black
+
+[Default]
+Font\Family=Overpass
+Palette\WindowText=#ECECEC
+Palette\Text=#ECECEC


### PR DESCRIPTION
This PR essentially implements the few remaining SNN properties that weren't displayed in the GUI for the previous sprint review. Along this feature, a few more elements have been added to the code:

- All SNN properties have been implemented in `ParamsRack.qml` and can be modified.
- A new widget, `SwitchField.qml`, was created. This is a simple toggle switch UI element.
- The design for `SliderField.qml` was revisited and reapplied across all instances of the application, in response to concerns about its visual precision and general ease of use. As a result, there is currently a strong visual imbalance between the newly updated and the already present designs, so this will undoubtedly need some more work.
- In order to properly enable all `SelectField` instances' I/O functionalities, the `NeuronType` enumeration was refactored into its own QObject definition and redefined across all C++ files.
- A few global styles were added to `qtquickcontrols2.conf` for general code cleanup purposes.

Right now, all parameters are visible at all times in the GUI, which is obviously far from optimal. Eventually, we will have to implement a proper page system (which I have already pitched into issue #97), but I believe that having all parameters functioning properly and correctly affecting the SNN's behaviour is a top priority for us at the moment.