### PR TITLE
Add "deactivated" property to all fields

### DIFF
--- a/DynamicLights/Fields/AreaField.qml
+++ b/DynamicLights/Fields/AreaField.qml
@@ -17,6 +17,7 @@ Field {
         Layout.fillHeight: true
 
         FieldFrame {
+            enabled: !deactivated
             isHovered: textArea.hovered
             isFocused: textArea.activeFocus
         }
@@ -26,8 +27,12 @@ Field {
             anchors.fill: parent
             maximumFlickVelocity: 350
 
+            enabled: !deactivated
+
             TextArea.flickable: TextArea {
                 id: textArea
+
+                enabled: !deactivated
 
                 // root settings
                 text: defaultText

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -33,9 +33,8 @@ ColumnLayout {
     }
 
     // animations
-    state: deactivated ? "deactivated" : ""
     states: State {
-        name: "deactivated"
+        name: "deactivated"; when: field.deactivated
         PropertyChanges { target: field; opacity: 0.25 }
     }
     Behavior on opacity {

--- a/DynamicLights/Fields/Field.qml
+++ b/DynamicLights/Fields/Field.qml
@@ -9,6 +9,7 @@ ColumnLayout {
 
     property string labelText: "Label"
     property int fieldWidth: Stylesheet.field.initialWidth
+    property bool deactivated: false
 
     signal valueChanged(variant newValue)
 
@@ -28,6 +29,20 @@ ColumnLayout {
             pixelSize: 13
             letterSpacing: 13 * 0.05
             capitalization: Font.AllUppercase
+        }
+    }
+
+    // animations
+    state: deactivated ? "deactivated" : ""
+    states: State {
+        name: "deactivated"
+        PropertyChanges { target: field; opacity: 0.25 }
+    }
+    Behavior on opacity {
+        NumberAnimation {
+            property: "opacity"
+            duration: 300
+            easing.type: Easing.InOutQuad
         }
     }
 }

--- a/DynamicLights/Fields/FieldFrame.qml
+++ b/DynamicLights/Fields/FieldFrame.qml
@@ -12,15 +12,33 @@ Item {
     anchors.fill: parent
 
     Repeater {
+        id: frameLines
         model: ["top", "bottom"]
 
         Rectangle {
+            id: line
             width: parent.width
             height: 1
             anchors.top: modelData == "top" ? parent.top : undefined
             anchors.bottom: modelData == "bottom" ? parent.bottom : undefined
             color: Stylesheet.colors.white
-            opacity: isHovered ? 1 : (isFocused ? 1 : 0.5)
+            opacity: 0.5
+
+            // states
+            state: isHovered ? "active" : (isFocused ? "active" : "")
+            states: State {
+                name: "active"
+                PropertyChanges { target: line; opacity: 1 }
+            }
+
+            // animations
+            Behavior on opacity {
+                NumberAnimation {
+                    property: "opacity"
+                    duration: 150
+                    easing.type: Easing.InOutQuad
+                }
+            }
         }
     }
 }

--- a/DynamicLights/Fields/FieldFrame.qml
+++ b/DynamicLights/Fields/FieldFrame.qml
@@ -25,9 +25,8 @@ Item {
             opacity: 0.5
 
             // states
-            state: isHovered ? "active" : (isFocused ? "active" : "")
             states: State {
-                name: "active"
+                name: "active"; when: isHovered || isFocused
                 PropertyChanges { target: line; opacity: 1 }
             }
 

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -97,9 +97,8 @@ Field {
         }
 
         // animations
-        state: down ? "down" : ""
         states: State {
-            name: "down"
+            name: "down"; when: comboBox.down
             PropertyChanges {
                 target: indicatorRot
                 angle: 180

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -90,9 +90,28 @@ Field {
 
             // auto rotate
             transform: Rotation {
-                angle: comboBox.down ? 180 : 0
+                id: indicatorRot
                 origin.x: indicator.width / 2
                 origin.y: indicator.height / 2
+            }
+        }
+
+        // animations
+        state: down ? "down" : ""
+        states: State {
+            name: "down"
+            PropertyChanges {
+                target: indicatorRot
+                angle: 180
+            }
+        }
+
+        transitions: Transition {
+            NumberAnimation {
+                target: indicatorRot
+                property: "angle"
+                duration: 400
+                easing.type: Easing.OutCubic
             }
         }
     }

--- a/DynamicLights/Fields/SelectField.qml
+++ b/DynamicLights/Fields/SelectField.qml
@@ -17,12 +17,15 @@ Field {
         currentIndex: selectField.index
         model: options
 
+        enabled: !deactivated
+
         onCurrentIndexChanged: selectField.valueChanged(currentIndex)
 
         // background
         background: FieldFrame {
-            frameWidth: fieldWidth
+            enabled: !deactivated
             isHovered: comboBox.hovered
+            isFocused: comboBox.down
         }
 
         // options delegate
@@ -67,7 +70,7 @@ Field {
             contentItem: ListView {
                 clip: true
                 implicitHeight: contentHeight
-                model: comboBox.popup.visible ? comboBox.delegateModel : null
+                model: comboBox.down ? comboBox.delegateModel : null
 
                 ScrollIndicator.vertical: ScrollIndicator {}
             }
@@ -87,7 +90,7 @@ Field {
 
             // auto rotate
             transform: Rotation {
-                angle: comboBox.popup.visible ? 180 : 0
+                angle: comboBox.down ? 180 : 0
                 origin.x: indicator.width / 2
                 origin.y: indicator.height / 2
             }

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -34,9 +34,6 @@ Field {
         Layout.preferredHeight: 40
         spacing: 3
 
-        // current state
-        state: slider.pressed ? "pressed" : (slider.hovered ? "hovered" : "")
-
         // slider
         Slider {
             id: slider
@@ -136,16 +133,29 @@ Field {
             }
         }
 
-        // states
+        // states & transitions
+        // current state (apparently I have to set it like this for it to work properly instead of using "when" in each state)
+        state: slider.pressed ? "pressed" : (slider.hovered ? "hovered" : "")
         states: [
             State {
-                name: "hovered"
+                name: "hovered";
                 PropertyChanges { target: trueHandle; handleColor: Stylesheet.colors.white }
             },
 
             State {
-                name: "pressed"
+                name: "pressed";
                 PropertyChanges { target: trueHandle; handleColor: Stylesheet.colors.outputs[0] }
+            }
+        ]
+        transitions: [
+            Transition {
+                from: ""; to: "hovered"
+                ColorAnimation { target: trueHandle; properties: "handleColor"; duration: 250; easing.type: Easing.InOutQuad }
+            },
+
+            Transition {
+                from: "hovered"; to: ""
+                ColorAnimation { target: trueHandle; properties: "handleColor"; duration: 250; easing.type: Easing.InOutQuad }
             }
         ]
     }

--- a/DynamicLights/Fields/SliderField.qml
+++ b/DynamicLights/Fields/SliderField.qml
@@ -41,6 +41,8 @@ Field {
         Slider {
             id: slider
 
+            enabled: !deactivated
+
             // alignment
             Layout.fillWidth: true
             Layout.preferredHeight: 10 + trueHandle.height
@@ -109,6 +111,8 @@ Field {
 
         TextField {
             id: sliderValue
+
+            enabled: !deactivated
 
             // alignment
             padding: 0

--- a/DynamicLights/Fields/SwitchField.qml
+++ b/DynamicLights/Fields/SwitchField.qml
@@ -14,6 +14,8 @@ Field {
     Switch {
         id: switchObj
 
+        enabled: !deactivated
+
         checked: switchField.on
         onToggled: switchField.valueChanged(checked)
 

--- a/DynamicLights/Fields/TextField.qml
+++ b/DynamicLights/Fields/TextField.qml
@@ -20,9 +20,12 @@ Field {
     TextField {
         id: fieldInput
 
+        enabled: !deactivated
+
         // alignment
         leftPadding: 0
-        height: 40
+        Layout.fillWidth: true
+        Layout.preferredHeight: 40
 
         // text
         text: activeFocus ? defaultText : metrics.elidedText
@@ -39,6 +42,7 @@ Field {
 
         // background
         background: FieldFrame {
+            enabled: !deactivated
             isHovered: fieldInput.hovered
             isFocused: fieldInput.activeFocus
         }

--- a/DynamicLights/Racks/ParamsRack.qml
+++ b/DynamicLights/Racks/ParamsRack.qml
@@ -124,6 +124,7 @@ Rack {
                 spacing: 0
 
                 SwitchField {
+                    id: stpFlag
                     labelText: "STP"
 
                     on: genID < 0 ? 0 : generatorModel.at(genID).flagSTP
@@ -136,6 +137,7 @@ Rack {
 
                     currVal: genID < 0 ? 0 : generatorModel.at(genID).STPStrength
                     onValueChanged: generatorModel.at(genID).STPStrength = newValue
+                    deactivated: !stpFlag.on
                 }
             }
 
@@ -143,6 +145,7 @@ Rack {
                 spacing: 0
 
                 SwitchField {
+                    id: stdpFlag
                     labelText: "STDP"
 
                     on: genID < 0 ? 0 : generatorModel.at(genID).flagSTDP
@@ -155,6 +158,7 @@ Rack {
 
                     currVal: genID < 0 ? 0 : generatorModel.at(genID).STDPStrength
                     onValueChanged: generatorModel.at(genID).STDPStrength = newValue
+                    deactivated: !stdpFlag.on
                 }
             }
 
@@ -162,6 +166,7 @@ Rack {
                 spacing: 0
 
                 SwitchField {
+                    id: decayFlag
                     labelText: "Decay"
 
                     on: genID < 0 ? 0 : generatorModel.at(genID).flagDecay
@@ -174,6 +179,7 @@ Rack {
 
                     currVal: genID < 0 ? 0 : generatorModel.at(genID).decayConstant
                     onValueChanged: generatorModel.at(genID).decayConstant = newValue
+                    deactivated: !decayFlag.on
                 }
             }
         }

--- a/DynamicLights/Racks/Rack.qml
+++ b/DynamicLights/Racks/Rack.qml
@@ -87,6 +87,9 @@ Item {
 
                     // i don't really like how the NumberAnimation component is essentially doubled
                     // but whatever this works for now i think
+
+                    // TODO: if i ever find a nicer way to implement this
+                    // make sure i also apply it to the SliderField handle anim. management
                     transitions: [
                         Transition {
                             from: ""; to: "hovered"
@@ -97,7 +100,6 @@ Item {
                             from: "hovered"; to: ""
                             NumberAnimation { target: btnCollapseBg; properties: "opacity"; duration: 250; easing.type: Easing.InOutQuad }
                         }
-
                     ]
                 }
 


### PR DESCRIPTION
This PR closes #104.

A new property, `deactivated`, was added to the `Field` component. Set to `false` by default, it can be conditionally linked to another field or by user interaction. When set to `true`, it will appear greyed out, and will automatically prevent any and all incoming events, mouse and keyboard.

A working example can be tested in the Parameters rack, through the relation between the STP, STDP and Decay flags and their respective slider fields.

![ezgif com-video-to-gif](https://user-images.githubusercontent.com/34627009/87359885-d58e4c80-c536-11ea-8e49-085fe5357c7f.gif)

Along with this PR, a few field-related animations were also added.

