### PR TITLE
Implement generator history graph

### DIFF
--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -32,7 +32,7 @@ private:
     double frequency = 80;
     bool firstFrame = true;
     bool flagDebug = false;
-    bool flagDummyOutputMonitor = true;
+    bool flagDummyOutputMonitor = false;
     bool flagDisableProcessing = false;
     std::mt19937 randomGenerator;
 std::uniform_real_distribution<> randomUniform;

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -32,7 +32,7 @@ private:
     double frequency = 80;
     bool firstFrame = true;
     bool flagDebug = false;
-    bool flagDummyOutputMonitor = false;
+    bool flagDummyOutputMonitor = true;
     bool flagDisableProcessing = false;
     std::mt19937 randomGenerator;
 std::uniform_real_distribution<> randomUniform;

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -29,7 +29,7 @@ Generator::Generator(QObject *parent) : QObject(parent) {
         qDebug() << "constructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
-    outputMonitorHistory = QSharedPointer<QVector<double>>(new QVector<double>(outputMonitorHistorySizeMax));
+    outputMonitorHistory = QSharedPointer<QVector<qreal>>(new QVector<qreal>(outputMonitorHistorySizeMax));
 }
 
 
@@ -75,8 +75,8 @@ double Generator::getOutputMonitor() {
     return outputMonitor;
 }
 
-QSharedPointer<QVector<double>> Generator::getOutputMonitorHistory() {
-    return outputMonitorHistory;
+QVector<qreal> Generator::getOutputMonitorHistory() {
+    return *outputMonitorHistory;
 }
 
 int Generator::getOutputMonitorHistoryStartIndex() {
@@ -171,7 +171,8 @@ void Generator::writeOutputMonitor(double value) {
         // increment start index
         outputMonitorHistoryStartIndex = (outputMonitorHistoryStartIndex + 1) % outputMonitorHistorySizeMax;
         // emit signals
-        // emit outputMonitorHistoryChanged(outputMonitorHistory);
+        emit valueChanged("outputMonitorHistory", QVariant::fromValue(*outputMonitorHistory));
+        emit outputMonitorHistoryChanged(*outputMonitorHistory);
         emit valueChanged("outputMonitorHistoryStartIndex", outputMonitorHistoryStartIndex);
         emit outputMonitorHistoryStartIndexChanged(outputMonitorHistoryStartIndex);
     } else {
@@ -184,7 +185,8 @@ void Generator::writeOutputMonitor(double value) {
         // increment valid size
         outputMonitorHistorySizeValid++;
         // emit signals
-        // emit outputMonitorHistoryChanged(outputMonitorHistory);
+        emit valueChanged("outputMonitorHistory", QVariant::fromValue(*outputMonitorHistory));
+        emit outputMonitorHistoryChanged(*outputMonitorHistory);
         emit valueChanged("outputMonitorHistorySizeValid", outputMonitorHistorySizeValid);
         emit outputMonitorHistorySizeValidChanged(outputMonitorHistorySizeValid);
     }

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -28,8 +28,6 @@ Generator::Generator(QObject *parent) : QObject(parent) {
 
         qDebug() << "constructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
-
-    outputMonitorHistory = QSharedPointer<QVector<qreal>>(new QVector<qreal>(outputMonitorHistorySizeMax));
 }
 
 
@@ -73,22 +71,6 @@ QString Generator::getDescription() {
 
 double Generator::getOutputMonitor() {
     return outputMonitor;
-}
-
-QVector<qreal> Generator::getOutputMonitorHistory() {
-    return *outputMonitorHistory;
-}
-
-int Generator::getOutputMonitorHistoryStartIndex() {
-    return outputMonitorHistoryStartIndex;
-}
-
-int Generator::getOutputMonitorHistorySizeMax() {
-    return outputMonitorHistorySizeMax;
-}
-
-int Generator::getOutputMonitorHistorySizeValid() {
-    return outputMonitorHistorySizeValid;
 }
 
 void Generator::writeName(QString string) {
@@ -160,51 +142,8 @@ void Generator::writeOutputMonitor(double value) {
 
     outputMonitor = value;
 
-    // update history buffer
-    if(outputMonitorHistorySizeValid == outputMonitorHistorySizeMax) {
-        // buffer is full
-
-        // index to write to is the previous start index
-        int index = outputMonitorHistoryStartIndex;
-        // write new value
-        (*outputMonitorHistory)[index] = value;
-        // increment start index
-        outputMonitorHistoryStartIndex = (outputMonitorHistoryStartIndex + 1) % outputMonitorHistorySizeMax;
-        // emit signals
-        emit valueChanged("outputMonitorHistory", QVariant::fromValue(*outputMonitorHistory));
-        emit outputMonitorHistoryChanged(*outputMonitorHistory);
-        emit valueChanged("outputMonitorHistoryStartIndex", outputMonitorHistoryStartIndex);
-        emit outputMonitorHistoryStartIndexChanged(outputMonitorHistoryStartIndex);
-    } else {
-        // buffer is not full yet
-
-        // index to write to is at start index offset by valid size
-        int index = (outputMonitorHistoryStartIndex + outputMonitorHistorySizeValid) % outputMonitorHistorySizeMax;
-        // write new value
-        (*outputMonitorHistory)[index] = value;
-        // increment valid size
-        outputMonitorHistorySizeValid++;
-        // emit signals
-        emit valueChanged("outputMonitorHistory", QVariant::fromValue(*outputMonitorHistory));
-        emit outputMonitorHistoryChanged(*outputMonitorHistory);
-        emit valueChanged("outputMonitorHistorySizeValid", outputMonitorHistorySizeValid);
-        emit outputMonitorHistorySizeValidChanged(outputMonitorHistorySizeValid);
-    }
-
     emit valueChanged("outputMonitor", QVariant(value));
     emit outputMonitorChanged(outputMonitor);
-
-    /*
-    qDebug() << "";
-    for(int index = 0; index < outputMonitorHistorySizeMax; index++) {
-        if((index >= outputMonitorHistoryStartIndex && index < outputMonitorHistoryStartIndex + outputMonitorHistorySizeValid) || (index + outputMonitorHistorySizeMax < outputMonitorHistoryStartIndex + outputMonitorHistorySizeValid)) {
-            qDebug() << "index: " << index << "\tvalue: " << (*outputMonitorHistory)[index];
-        } else {
-            qDebug() << "index: " << index << "\tvalue: unassigned";
-        }
-
-    }
-    */
 }
 
 void Generator::updateValue(const QString &key, const QVariant &value) {

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -159,8 +159,6 @@ void Generator::writeOutputMonitor(double value) {
     }
 
     outputMonitor = value;
-    emit valueChanged("outputMonitor", QVariant(value));
-    emit outputMonitorChanged(outputMonitor);
 
     // update history buffer
     if(outputMonitorHistorySizeValid == outputMonitorHistorySizeMax) {
@@ -173,7 +171,8 @@ void Generator::writeOutputMonitor(double value) {
         // increment start index
         outputMonitorHistoryStartIndex = (outputMonitorHistoryStartIndex + 1) % outputMonitorHistorySizeMax;
         // emit signals
-        emit outputMonitorHistoryChanged(outputMonitorHistory);
+        // emit outputMonitorHistoryChanged(outputMonitorHistory);
+        emit valueChanged("outputMonitorHistoryStartIndex", outputMonitorHistoryStartIndex);
         emit outputMonitorHistoryStartIndexChanged(outputMonitorHistoryStartIndex);
     } else {
         // buffer is not full yet
@@ -185,9 +184,13 @@ void Generator::writeOutputMonitor(double value) {
         // increment valid size
         outputMonitorHistorySizeValid++;
         // emit signals
-        emit outputMonitorHistoryChanged(outputMonitorHistory);
+        // emit outputMonitorHistoryChanged(outputMonitorHistory);
+        emit valueChanged("outputMonitorHistorySizeValid", outputMonitorHistorySizeValid);
         emit outputMonitorHistorySizeValidChanged(outputMonitorHistorySizeValid);
     }
+
+    emit valueChanged("outputMonitor", QVariant(value));
+    emit outputMonitorChanged(outputMonitor);
 
     /*
     qDebug() << "";

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -14,6 +14,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "Generator.h"
+#include <QDebug>
 
 #include <chrono>
 #include <QThread>
@@ -27,6 +28,8 @@ Generator::Generator(QObject *parent) : QObject(parent) {
 
         qDebug() << "constructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
+
+    outputMonitorHistory = QSharedPointer<QVector<double>>(new QVector<double>(outputMonitorHistorySizeMax));
 }
 
 
@@ -70,6 +73,22 @@ QString Generator::getDescription() {
 
 double Generator::getOutputMonitor() {
     return outputMonitor;
+}
+
+QSharedPointer<QVector<double>> Generator::getOutputMonitorHistory() {
+    return outputMonitorHistory;
+}
+
+int Generator::getOutputMonitorHistoryStartIndex() {
+    return outputMonitorHistoryStartIndex;
+}
+
+int Generator::getOutputMonitorHistorySizeMax() {
+    return outputMonitorHistorySizeMax;
+}
+
+int Generator::getOutputMonitorHistorySizeValid() {
+    return outputMonitorHistorySizeValid;
 }
 
 void Generator::writeName(QString string) {
@@ -142,6 +161,45 @@ void Generator::writeOutputMonitor(double value) {
     outputMonitor = value;
     emit valueChanged("outputMonitor", QVariant(value));
     emit outputMonitorChanged(outputMonitor);
+
+    // update history buffer
+    if(outputMonitorHistorySizeValid == outputMonitorHistorySizeMax) {
+        // buffer is full
+
+        // index to write to is the previous start index
+        int index = outputMonitorHistoryStartIndex;
+        // write new value
+        (*outputMonitorHistory)[index] = value;
+        // increment start index
+        outputMonitorHistoryStartIndex = (outputMonitorHistoryStartIndex + 1) % outputMonitorHistorySizeMax;
+        // emit signals
+        emit outputMonitorHistoryChanged(outputMonitorHistory);
+        emit outputMonitorHistoryStartIndexChanged(outputMonitorHistoryStartIndex);
+    } else {
+        // buffer is not full yet
+
+        // index to write to is at start index offset by valid size
+        int index = (outputMonitorHistoryStartIndex + outputMonitorHistorySizeValid) % outputMonitorHistorySizeMax;
+        // write new value
+        (*outputMonitorHistory)[index] = value;
+        // increment valid size
+        outputMonitorHistorySizeValid++;
+        // emit signals
+        emit outputMonitorHistoryChanged(outputMonitorHistory);
+        emit outputMonitorHistorySizeValidChanged(outputMonitorHistorySizeValid);
+    }
+
+    /*
+    qDebug() << "";
+    for(int index = 0; index < outputMonitorHistorySizeMax; index++) {
+        if((index >= outputMonitorHistoryStartIndex && index < outputMonitorHistoryStartIndex + outputMonitorHistorySizeValid) || (index + outputMonitorHistorySizeMax < outputMonitorHistoryStartIndex + outputMonitorHistorySizeValid)) {
+            qDebug() << "index: " << index << "\tvalue: " << (*outputMonitorHistory)[index];
+        } else {
+            qDebug() << "index: " << index << "\tvalue: unassigned";
+        }
+
+    }
+    */
 }
 
 void Generator::updateValue(const QString &key, const QVariant &value) {

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -29,7 +29,7 @@ class Generator : public QObject
     Q_PROPERTY(QString type READ getType NOTIFY typeChanged)
     Q_PROPERTY(QString description READ getDescription WRITE writeDescription NOTIFY descriptionChanged)
     Q_PROPERTY(double outputMonitor READ getOutputMonitor NOTIFY outputMonitorChanged)
-    Q_PROPERTY(QSharedPointer<QVector<double>> outputMonitorHistory READ getOutputMonitorHistory NOTIFY outputMonitorHistoryChanged)
+    Q_PROPERTY(QVector<qreal> outputMonitorHistory READ getOutputMonitorHistory NOTIFY outputMonitorHistoryChanged)
     Q_PROPERTY(int outputMonitorHistoryStartIndex READ getOutputMonitorHistoryStartIndex NOTIFY outputMonitorHistoryStartIndexChanged)
     Q_PROPERTY(int outputMonitorHistorySizeMax READ getOutputMonitorHistorySizeMax NOTIFY outputMonitorHistorySizeMaxChanged)
     Q_PROPERTY(int outputMonitorHistorySizeValid READ getOutputMonitorHistorySizeValid NOTIFY outputMonitorHistorySizeValidChanged)
@@ -43,7 +43,7 @@ protected:
     QString type;           // generator type, fixed
     QString description;    // generator description, fixed
     double outputMonitor;   // output monitor / indicator light, generated from output array automatically by ComputeEngine
-    QSharedPointer<QVector<double>> outputMonitorHistory;   // circular buffer containing the history of the output monitor
+    QSharedPointer<QVector<qreal>> outputMonitorHistory;   // circular buffer containing the history of the output monitor
     int outputMonitorHistoryStartIndex = 0;                 // index of the first element in the buffer (historically the oldest element)
     int outputMonitorHistorySizeMax = 32;                   // size of the circular buffer
     int outputMonitorHistorySizeValid = 0;                  // number of valid entries in the circular buffer (initialized to 0 since the buffer will be empty)
@@ -82,7 +82,7 @@ public:
     QString getType();
     QString getDescription();
     double getOutputMonitor();
-    QSharedPointer<QVector<double>> getOutputMonitorHistory();
+    QVector<qreal> getOutputMonitorHistory();
     int getOutputMonitorHistoryStartIndex();
     int getOutputMonitorHistorySizeMax();
     int getOutputMonitorHistorySizeValid();
@@ -101,7 +101,7 @@ signals:
     void typeChanged(QString);
     void descriptionChanged(QString);
     void outputMonitorChanged(double);
-    void outputMonitorHistoryChanged(QSharedPointer<QVector<double>>);
+    void outputMonitorHistoryChanged(QVector<qreal>);
     void outputMonitorHistoryStartIndexChanged(int);
     void outputMonitorHistorySizeMaxChanged(int);
     void outputMonitorHistorySizeValidChanged(int);

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -29,10 +29,6 @@ class Generator : public QObject
     Q_PROPERTY(QString type READ getType NOTIFY typeChanged)
     Q_PROPERTY(QString description READ getDescription WRITE writeDescription NOTIFY descriptionChanged)
     Q_PROPERTY(double outputMonitor READ getOutputMonitor NOTIFY outputMonitorChanged)
-    Q_PROPERTY(QVector<qreal> outputMonitorHistory READ getOutputMonitorHistory NOTIFY outputMonitorHistoryChanged)
-    Q_PROPERTY(int outputMonitorHistoryStartIndex READ getOutputMonitorHistoryStartIndex NOTIFY outputMonitorHistoryStartIndexChanged)
-    Q_PROPERTY(int outputMonitorHistorySizeMax READ getOutputMonitorHistorySizeMax NOTIFY outputMonitorHistorySizeMaxChanged)
-    Q_PROPERTY(int outputMonitorHistorySizeValid READ getOutputMonitorHistorySizeValid NOTIFY outputMonitorHistorySizeValidChanged)
 protected:
     // the generator class provides input and output buffers
     std::vector<double> input;
@@ -43,10 +39,6 @@ protected:
     QString type;           // generator type, fixed
     QString description;    // generator description, fixed
     double outputMonitor;   // output monitor / indicator light, generated from output array automatically by ComputeEngine
-    QSharedPointer<QVector<qreal>> outputMonitorHistory;    // circular buffer containing the history of the output monitor
-    int outputMonitorHistoryStartIndex = 0;                 // index of the first element in the buffer (historically the oldest element)
-    int outputMonitorHistorySizeMax = 2048;                 // size of the circular buffer
-    int outputMonitorHistorySizeValid = 0;                  // number of valid entries in the circular buffer (initialized to 0 since the buffer will be empty)
 
     // example for indexing outputMonitorHistory:
 
@@ -82,10 +74,6 @@ public:
     QString getType();
     QString getDescription();
     double getOutputMonitor();
-    QVector<qreal> getOutputMonitorHistory();
-    int getOutputMonitorHistoryStartIndex();
-    int getOutputMonitorHistorySizeMax();
-    int getOutputMonitorHistorySizeValid();
 
     void writeName(QString string);
     void writeType(QString string);
@@ -101,8 +89,4 @@ signals:
     void typeChanged(QString);
     void descriptionChanged(QString);
     void outputMonitorChanged(double);
-    void outputMonitorHistoryChanged(QVector<qreal>);
-    void outputMonitorHistoryStartIndexChanged(int);
-    void outputMonitorHistorySizeMaxChanged(int);
-    void outputMonitorHistorySizeValidChanged(int);
 };

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -47,6 +47,23 @@ protected:
     int outputMonitorHistoryStartIndex = 0;                 // index of the first element in the buffer (historically the oldest element)
     int outputMonitorHistorySizeMax = 32;                   // size of the circular buffer
     int outputMonitorHistorySizeValid = 0;                  // number of valid entries in the circular buffer (initialized to 0 since the buffer will be empty)
+
+    // example for indexing outputMonitorHistory:
+
+    // indexing chronologically (oldest to newest)
+    //
+    //  for(int i = 0; i < outputMonitorHistorySizeValid; i++) {
+    //      int index = (outputMonitorHistoryStartIndex + i) % outputMonitorHistorySizeMax;
+    //  }
+    //
+
+    // indexing reverse-chronologically (newest to oldest)
+    //
+    //  for(int i = 0; i < outputMonitorHistorySizeValid; i++) {
+    //      int index = (outputMonitorHistoryStartIndex + outputMonitorHistorySizeValid - 1 - i + outputMonitorHistorySizeMax) % outputMonitorHistorySizeMax;
+    //  }
+    //
+
 public:
     explicit Generator(QObject *parent = nullptr);
     ~Generator();

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -43,9 +43,9 @@ protected:
     QString type;           // generator type, fixed
     QString description;    // generator description, fixed
     double outputMonitor;   // output monitor / indicator light, generated from output array automatically by ComputeEngine
-    QSharedPointer<QVector<qreal>> outputMonitorHistory;   // circular buffer containing the history of the output monitor
+    QSharedPointer<QVector<qreal>> outputMonitorHistory;    // circular buffer containing the history of the output monitor
     int outputMonitorHistoryStartIndex = 0;                 // index of the first element in the buffer (historically the oldest element)
-    int outputMonitorHistorySizeMax = 32;                   // size of the circular buffer
+    int outputMonitorHistorySizeMax = 256;                  // size of the circular buffer
     int outputMonitorHistorySizeValid = 0;                  // number of valid entries in the circular buffer (initialized to 0 since the buffer will be empty)
 
     // example for indexing outputMonitorHistory:

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -18,6 +18,8 @@
 #include <QObject>
 #include <QString>
 #include <QVariant>
+#include <QVector>
+#include <QSharedPointer>
 #include <vector>
 
 class Generator : public QObject
@@ -27,6 +29,10 @@ class Generator : public QObject
     Q_PROPERTY(QString type READ getType NOTIFY typeChanged)
     Q_PROPERTY(QString description READ getDescription WRITE writeDescription NOTIFY descriptionChanged)
     Q_PROPERTY(double outputMonitor READ getOutputMonitor NOTIFY outputMonitorChanged)
+    Q_PROPERTY(QSharedPointer<QVector<double>> outputMonitorHistory READ getOutputMonitorHistory NOTIFY outputMonitorHistoryChanged)
+    Q_PROPERTY(int outputMonitorHistoryStartIndex READ getOutputMonitorHistoryStartIndex NOTIFY outputMonitorHistoryStartIndexChanged)
+    Q_PROPERTY(int outputMonitorHistorySizeMax READ getOutputMonitorHistorySizeMax NOTIFY outputMonitorHistorySizeMaxChanged)
+    Q_PROPERTY(int outputMonitorHistorySizeValid READ getOutputMonitorHistorySizeValid NOTIFY outputMonitorHistorySizeValidChanged)
 protected:
     // the generator class provides input and output buffers
     std::vector<double> input;
@@ -37,6 +43,10 @@ protected:
     QString type;           // generator type, fixed
     QString description;    // generator description, fixed
     double outputMonitor;   // output monitor / indicator light, generated from output array automatically by ComputeEngine
+    QSharedPointer<QVector<double>> outputMonitorHistory;   // circular buffer containing the history of the output monitor
+    int outputMonitorHistoryStartIndex = 0;                 // index of the first element in the buffer (historically the oldest element)
+    int outputMonitorHistorySizeMax = 32;                   // size of the circular buffer
+    int outputMonitorHistorySizeValid = 0;                  // number of valid entries in the circular buffer (initialized to 0 since the buffer will be empty)
 public:
     explicit Generator(QObject *parent = nullptr);
     ~Generator();
@@ -55,6 +65,10 @@ public:
     QString getType();
     QString getDescription();
     double getOutputMonitor();
+    QSharedPointer<QVector<double>> getOutputMonitorHistory();
+    int getOutputMonitorHistoryStartIndex();
+    int getOutputMonitorHistorySizeMax();
+    int getOutputMonitorHistorySizeValid();
 
     void writeName(QString string);
     void writeType(QString string);
@@ -70,4 +84,8 @@ signals:
     void typeChanged(QString);
     void descriptionChanged(QString);
     void outputMonitorChanged(double);
+    void outputMonitorHistoryChanged(QSharedPointer<QVector<double>>);
+    void outputMonitorHistoryStartIndexChanged(int);
+    void outputMonitorHistorySizeMaxChanged(int);
+    void outputMonitorHistorySizeValidChanged(int);
 };

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -45,7 +45,7 @@ protected:
     double outputMonitor;   // output monitor / indicator light, generated from output array automatically by ComputeEngine
     QSharedPointer<QVector<qreal>> outputMonitorHistory;    // circular buffer containing the history of the output monitor
     int outputMonitorHistoryStartIndex = 0;                 // index of the first element in the buffer (historically the oldest element)
-    int outputMonitorHistorySizeMax = 256;                  // size of the circular buffer
+    int outputMonitorHistorySizeMax = 2048;                 // size of the circular buffer
     int outputMonitorHistorySizeValid = 0;                  // number of valid entries in the circular buffer (initialized to 0 since the buffer will be empty)
 
     // example for indexing outputMonitorHistory:

--- a/DynamicLights/GeneratorModel.cpp
+++ b/DynamicLights/GeneratorModel.cpp
@@ -36,30 +36,10 @@ GeneratorModel::GeneratorModel(QSharedPointer<QList<QSharedPointer<Facade>>> gen
             QVector<int> roles;
             bool unrecognized = false;
 
-            int role = roleNames().key(key.toUtf8());
-            if (role == 0) unrecognized = true;         // is this is a fully error-proof check?
+            int role = roleMap.key(key.toUtf8(), -1);
+            // check to see if the value exists in the hash map
+            if (role == -1) unrecognized = true;
             else roles = { role };
-
-            // TODO: this is dumb duplicated code that could be streamlined by instead using the roleNames() hashMap. rewritten above.
-//            if(key == "name") {
-//                roles = {NameRole};
-//            } else if (key == "type") {
-//                roles = {TypeRole};
-//            } else if (key == "description") {
-//                roles = {DescriptionRole};
-//            } else if (key == "outputMonitor") {
-//                roles = {OutputMonitorRole};
-//            } else if (key == "outputMonitorHistory") {
-//                roles = {OutputMonitorHistoryRole};
-//            } else if (key == "outputMonitorHistoryStartIndex") {
-//                roles = {OutputMonitorHistoryStartIndexRole};
-//            } else if (key == "outputMonitorHistorySizeMax") {
-//                roles = {OutputMonitorHistorySizeMaxRole};
-//            } else if (key == "outputMonitorHistorySizeValid") {
-//                roles = {OutputMonitorHistorySizeValidRole};
-//            } else {
-//                unrecognized = true;
-//            }
 
             if(flagDebug) {
                 std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -104,64 +84,18 @@ QVariant GeneratorModel::data(const QModelIndex &index, int role) const {
     if(!index.isValid())
         return QVariant();
 
+    // check if the index is valid
     if(index.column() == 0 && index.row() >= 0 && index.row() < generatorFacades.get()->size()) {
-
-        // is a truthy-value check necessary here? or is the key always guaranteed to exist?
-        return generatorFacades.get()->at(index.row())->value(roleNames().value(role));
-
-        // TODO: this is dumb duplicated code that could be streamlined by instead using the roleNames() hashMap. rewritten above.
-//        switch(role) {
-//            case NameRole : {
-//                return generatorFacades[index.row()]->value("name");
-//                break;
-//            }
-//            case TypeRole : {
-//                return generatorFacades[index.row()]->value("type");
-//                break;
-//            }
-//            case DescriptionRole : {
-//                return generatorFacades[index.row()]->value("desctiption");
-//                break;
-//            }
-//            case OutputMonitorRole : {
-//                qDebug() << role;
-//                return generatorFacades[index.row()]->value("outputMonitor");
-//                break;
-//            }
-//            case OutputMonitorHistoryRole : {
-//                return generatorFacades[index.row()]->value("outputMonitorHistory");
-//                break;
-//            }
-//            case OutputMonitorHistoryStartIndexRole : {
-//                qDebug() << role;
-//                return generatorFacades[index.row()]->value("outputMonitorHistoryStartIndex");
-//                break;
-//            }
-//            case OutputMonitorHistorySizeMaxRole : {
-//                return generatorFacades[index.row()]->value("outputMonitorHistorySizeMax");
-//                break;
-//            }
-//            case OutputMonitorHistorySizeValidRole : {
-//                return generatorFacades[index.row()]->value("outputMonitorHistorySizeValid");
-//                break;
-//            }
-//        }
+        // check if the key exists in the hash map
+        if(roleMap.contains(role))
+            return generatorFacades.get()->at(index.row())->value(roleMap.value(role));
     }
 
     return QVariant();
 }
 
 QHash<int, QByteArray> GeneratorModel::roleNames() const {
-    QHash<int, QByteArray> roles;
-        roles[NameRole] = "name";
-        roles[TypeRole] = "type";
-        roles[DescriptionRole] = "description";
-        roles[OutputMonitorRole] = "outputMonitor";
-        roles[OutputMonitorHistoryRole] = "outputMonitorHistory";
-        roles[OutputMonitorHistoryStartIndexRole] = "outputMonitorHistoryStartIndex";
-        roles[OutputMonitorHistorySizeMaxRole] = "outputMonitorHistorySizeMax";
-        roles[OutputMonitorHistorySizeValidRole] = "outputMonitorHistorySizeValid";
-        return roles;
+    return roleMap;
 }
 
 Facade * GeneratorModel::at(int index) {

--- a/DynamicLights/GeneratorModel.cpp
+++ b/DynamicLights/GeneratorModel.cpp
@@ -36,27 +36,30 @@ GeneratorModel::GeneratorModel(QSharedPointer<QList<QSharedPointer<Facade>>> gen
             QVector<int> roles;
             bool unrecognized = false;
 
-            // TODO: this is dumb duplicated code that could be streamlined by instead using the roleNames() hashMap. rewrite this.
+            int role = roleNames().key(key.toUtf8());
+            if (role == 0) unrecognized = true;         // is this is a fully error-proof check?
+            else roles = { role };
 
-            if(key == "name") {
-                roles = {NameRole};
-            } else if (key == "type") {
-                roles = {TypeRole};
-            } else if (key == "description") {
-                roles = {DescriptionRole};
-            } else if (key == "outputMonitor") {
-                roles = {OutputMonitorRole};
-            } else if (key == "outputMonitorHistory") {
-                roles = {OutputMonitorHistoryRole};
-            } else if (key == "outputMonitorHistoryStartIndex") {
-                roles = {OutputMonitorHistoryStartIndexRole};
-            } else if (key == "outputMonitorHistorySizeMax") {
-                roles = {OutputMonitorHistorySizeMaxRole};
-            } else if (key == "outputMonitorHistorySizeValid") {
-                roles = {OutputMonitorHistorySizeValidRole};
-            } else {
-                unrecognized = true;
-            }
+            // TODO: this is dumb duplicated code that could be streamlined by instead using the roleNames() hashMap. rewritten above.
+//            if(key == "name") {
+//                roles = {NameRole};
+//            } else if (key == "type") {
+//                roles = {TypeRole};
+//            } else if (key == "description") {
+//                roles = {DescriptionRole};
+//            } else if (key == "outputMonitor") {
+//                roles = {OutputMonitorRole};
+//            } else if (key == "outputMonitorHistory") {
+//                roles = {OutputMonitorHistoryRole};
+//            } else if (key == "outputMonitorHistoryStartIndex") {
+//                roles = {OutputMonitorHistoryStartIndexRole};
+//            } else if (key == "outputMonitorHistorySizeMax") {
+//                roles = {OutputMonitorHistorySizeMaxRole};
+//            } else if (key == "outputMonitorHistorySizeValid") {
+//                roles = {OutputMonitorHistorySizeValidRole};
+//            } else {
+//                unrecognized = true;
+//            }
 
             if(flagDebug) {
                 std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -103,42 +106,46 @@ QVariant GeneratorModel::data(const QModelIndex &index, int role) const {
 
     if(index.column() == 0 && index.row() >= 0 && index.row() < generatorFacades.get()->size()) {
 
-        // TODO: this is dumb duplicated code that could be streamlined by instead using the roleNames() hashMap. rewrite this.
+        // is a truthy-value check necessary here? or is the key always guaranteed to exist?
+        return generatorFacades.get()->at(index.row())->value(roleNames().value(role));
 
-        switch(role) {
-            case NameRole : {
-                return generatorFacades.get()->at(index.row())->value("name");
-                break;
-            }
-            case TypeRole : {
-                return generatorFacades.get()->at(index.row())->value("type");
-                break;
-            }
-            case DescriptionRole : {
-                return generatorFacades.get()->at(index.row())->value("desctiption");
-                break;
-            }
-            case OutputMonitorRole : {
-                return generatorFacades.get()->at(index.row())->value("outputMonitor");
-                break;
-            }
-            case OutputMonitorHistoryRole : {
-                return generatorFacades.get()->at(index.row())->value("outputMonitorHistory");
-                break;
-            }
-            case OutputMonitorHistoryStartIndexRole : {
-                return generatorFacades.get()->at(index.row())->value("outputMonitorHistoryStartIndex");
-                break;
-            }
-            case OutputMonitorHistorySizeMaxRole : {
-                return generatorFacades.get()->at(index.row())->value("outputMonitorHistorySizeMax");
-                break;
-            }
-            case OutputMonitorHistorySizeValidRole : {
-                return generatorFacades.get()->at(index.row())->value("outputMonitorHistorySizeValid");
-                break;
-            }
-        }
+        // TODO: this is dumb duplicated code that could be streamlined by instead using the roleNames() hashMap. rewritten above.
+//        switch(role) {
+//            case NameRole : {
+//                return generatorFacades[index.row()]->value("name");
+//                break;
+//            }
+//            case TypeRole : {
+//                return generatorFacades[index.row()]->value("type");
+//                break;
+//            }
+//            case DescriptionRole : {
+//                return generatorFacades[index.row()]->value("desctiption");
+//                break;
+//            }
+//            case OutputMonitorRole : {
+//                qDebug() << role;
+//                return generatorFacades[index.row()]->value("outputMonitor");
+//                break;
+//            }
+//            case OutputMonitorHistoryRole : {
+//                return generatorFacades[index.row()]->value("outputMonitorHistory");
+//                break;
+//            }
+//            case OutputMonitorHistoryStartIndexRole : {
+//                qDebug() << role;
+//                return generatorFacades[index.row()]->value("outputMonitorHistoryStartIndex");
+//                break;
+//            }
+//            case OutputMonitorHistorySizeMaxRole : {
+//                return generatorFacades[index.row()]->value("outputMonitorHistorySizeMax");
+//                break;
+//            }
+//            case OutputMonitorHistorySizeValidRole : {
+//                return generatorFacades[index.row()]->value("outputMonitorHistorySizeValid");
+//                break;
+//            }
+//        }
     }
 
     return QVariant();

--- a/DynamicLights/GeneratorModel.cpp
+++ b/DynamicLights/GeneratorModel.cpp
@@ -36,6 +36,8 @@ GeneratorModel::GeneratorModel(QSharedPointer<QList<QSharedPointer<Facade>>> gen
             QVector<int> roles;
             bool unrecognized = false;
 
+            // TODO: this is dumb duplicated code that could be streamlined by instead using the roleNames() hashMap. rewrite this.
+
             if(key == "name") {
                 roles = {NameRole};
             } else if (key == "type") {
@@ -44,6 +46,14 @@ GeneratorModel::GeneratorModel(QSharedPointer<QList<QSharedPointer<Facade>>> gen
                 roles = {DescriptionRole};
             } else if (key == "outputMonitor") {
                 roles = {OutputMonitorRole};
+            } else if (key == "outputMonitorHistory") {
+                roles = {OutputMonitorHistoryRole};
+            } else if (key == "outputMonitorHistoryStartIndex") {
+                roles = {OutputMonitorHistoryStartIndexRole};
+            } else if (key == "outputMonitorHistorySizeMax") {
+                roles = {OutputMonitorHistorySizeMaxRole};
+            } else if (key == "outputMonitorHistorySizeValid") {
+                roles = {OutputMonitorHistorySizeValidRole};
             } else {
                 unrecognized = true;
             }
@@ -92,6 +102,9 @@ QVariant GeneratorModel::data(const QModelIndex &index, int role) const {
         return QVariant();
 
     if(index.column() == 0 && index.row() >= 0 && index.row() < generatorFacades.get()->size()) {
+
+        // TODO: this is dumb duplicated code that could be streamlined by instead using the roleNames() hashMap. rewrite this.
+
         switch(role) {
             case NameRole : {
                 return generatorFacades.get()->at(index.row())->value("name");
@@ -109,6 +122,22 @@ QVariant GeneratorModel::data(const QModelIndex &index, int role) const {
                 return generatorFacades.get()->at(index.row())->value("outputMonitor");
                 break;
             }
+            case OutputMonitorHistoryRole : {
+                return generatorFacades.get()->at(index.row())->value("outputMonitorHistory");
+                break;
+            }
+            case OutputMonitorHistoryStartIndexRole : {
+                return generatorFacades.get()->at(index.row())->value("outputMonitorHistoryStartIndex");
+                break;
+            }
+            case OutputMonitorHistorySizeMaxRole : {
+                return generatorFacades.get()->at(index.row())->value("outputMonitorHistorySizeMax");
+                break;
+            }
+            case OutputMonitorHistorySizeValidRole : {
+                return generatorFacades.get()->at(index.row())->value("outputMonitorHistorySizeValid");
+                break;
+            }
         }
     }
 
@@ -121,6 +150,10 @@ QHash<int, QByteArray> GeneratorModel::roleNames() const {
         roles[TypeRole] = "type";
         roles[DescriptionRole] = "description";
         roles[OutputMonitorRole] = "outputMonitor";
+        roles[OutputMonitorHistoryRole] = "outputMonitorHistory";
+        roles[OutputMonitorHistoryStartIndexRole] = "outputMonitorHistoryStartIndex";
+        roles[OutputMonitorHistorySizeMaxRole] = "outputMonitorHistorySizeMax";
+        roles[OutputMonitorHistorySizeValidRole] = "outputMonitorHistorySizeValid";
         return roles;
 }
 

--- a/DynamicLights/GeneratorModel.h
+++ b/DynamicLights/GeneratorModel.h
@@ -50,4 +50,14 @@ public:
 private:
     QSharedPointer<QList<QSharedPointer<Facade>>> generatorFacades;
     bool flagDebug = false;
+    const QHash<int, QByteArray> roleMap = {
+        {NameRole, "name"},
+        {TypeRole, "type"},
+        {DescriptionRole, "description"},
+        {OutputMonitorRole, "outputMonitor"},
+        {OutputMonitorHistoryRole, "outputMonitorHistory"},
+        {OutputMonitorHistoryStartIndexRole, "outputMonitorHistoryStartIndex"},
+        {OutputMonitorHistorySizeMaxRole, "outputMonitorHistorySizeMax"},
+        {OutputMonitorHistorySizeValidRole,"outputMonitorHistorySizeValid"}
+    };
 };

--- a/DynamicLights/GeneratorModel.h
+++ b/DynamicLights/GeneratorModel.h
@@ -29,7 +29,11 @@ public:
         NameRole = Qt::UserRole + 1,
         TypeRole,
         DescriptionRole,
-        OutputMonitorRole
+        OutputMonitorRole,
+        OutputMonitorHistoryRole,
+        OutputMonitorHistoryStartIndexRole,
+        OutputMonitorHistorySizeMaxRole,
+        OutputMonitorHistorySizeValidRole
     };
 
     GeneratorModel(QSharedPointer<QList<QSharedPointer<Facade>>> generators);

--- a/DynamicLights/GeneratorWidget.qml
+++ b/DynamicLights/GeneratorWidget.qml
@@ -37,6 +37,16 @@ Button {
 
 
     // TODO: graph
+    HistoryGraph {
+        id: historyGraph
+
+        startIndex: model ? model.outputMonitorHistoryStartIndex : 0
+        sizeMax: model ? model.outputMonitorHistorySizeMax : 0
+        sizeValid: model ? model.outputMonitorHistorySizeValid : 0
+        points: model ? model.outputMonitorHistory : []
+
+        strokeColor: Stylesheet.colors.outputs[model.index % Stylesheet.colors.outputs.length]
+    }
 
     // text content
     RowLayout {
@@ -50,9 +60,7 @@ Button {
             id: labelIndex
 
             text: model.index + 1
-            color: Stylesheet.colors.white
             font {
-                family: Stylesheet.fonts.main
                 weight: Font.Bold
                 pixelSize: 11
             }
@@ -67,9 +75,7 @@ Button {
             text: model.name
             color: selected ? Stylesheet.colors.black : Stylesheet.colors.white
             font {
-                family: Stylesheet.fonts.main
                 weight: Font.Normal
-                pixelSize: 18
             }
             opacity: selected ? 1 : (hovered ? 1 : 0.5)
         }

--- a/DynamicLights/GeneratorWidget.qml
+++ b/DynamicLights/GeneratorWidget.qml
@@ -40,10 +40,7 @@ Button {
     HistoryGraph {
         id: historyGraph
 
-        startIndex: model ? model.outputMonitorHistoryStartIndex : 0
-        sizeMax: model ? model.outputMonitorHistorySizeMax : 0
-        sizeValid: model ? model.outputMonitorHistorySizeValid : 0
-        points: model ? model.outputMonitorHistory : []
+        newValue: model ? model.outputMonitor : 0
 
         strokeColor: Stylesheet.colors.outputs[model.index % Stylesheet.colors.outputs.length]
     }

--- a/DynamicLights/HistoryGraph.qml
+++ b/DynamicLights/HistoryGraph.qml
@@ -8,7 +8,7 @@ Item {
     property int sizeMax
     property variant points
 
-    onStartIndexChanged: graphCanvas.requestPaint()
+    onPointsChanged: graphCanvas.requestPaint()
 
     property color strokeColor: "#fff"
 
@@ -21,16 +21,23 @@ Item {
         opacity: 0.5
 
         onPaint: {
+            console.log("JS execution");
+
             var ctx = getContext("2d");
             ctx.clearRect(0, 0, graphCanvas.width, graphCanvas.height);
             ctx.strokeStyle = strokeColor;
 
             var lX = graphCanvas.width / (sizeMax - 1);
 
+            console.log("range: [0, " + (sizeValid - 2) + "]");
+            console.log(points);
+
             ctx.beginPath();
-            for (var i = 0; i < sizeMax - 1; i++) {
-                ctx.moveTo(i * lX, points[(startIndex + i) % sizeMax] * graphCanvas.height);
-                ctx.lineTo((i + 1) * lX, points[(startIndex + i + 1) % sizeMax] * graphCanvas.height)
+            for (var i = 0; i < sizeValid - 1; i++) {
+                var indexStart = (startIndex + sizeValid - 1 - i + sizeMax) % sizeMax;
+                var indexEnd = (startIndex + sizeValid - i + sizeMax) % sizeMax;
+                ctx.moveTo(graphCanvas.width - i * lX, points[indexStart] * graphCanvas.height);
+                ctx.lineTo(graphCanvas.width - (i + 1) * lX, points[indexEnd] * graphCanvas.height)
             }
             ctx.closePath();
             ctx.stroke();

--- a/DynamicLights/HistoryGraph.qml
+++ b/DynamicLights/HistoryGraph.qml
@@ -21,16 +21,11 @@ Item {
         opacity: 0.5
 
         onPaint: {
-            console.log("JS execution");
-
             var ctx = getContext("2d");
             ctx.clearRect(0, 0, graphCanvas.width, graphCanvas.height);
             ctx.strokeStyle = strokeColor;
 
             var lX = graphCanvas.width / (sizeMax - 1);
-
-            console.log("range: [0, " + (sizeValid - 2) + "]");
-            console.log(points);
 
             ctx.beginPath();
             for (var i = 0; i < sizeValid - 1; i++) {

--- a/DynamicLights/HistoryGraph.qml
+++ b/DynamicLights/HistoryGraph.qml
@@ -3,24 +3,47 @@ import QtQuick 2.0
 Item {
     id: historyGraph
 
-    property int startIndex
-    property int sizeValid
-    property int sizeMax
-    property variant points
+    property real newValue
+    property variant history: []
+    property int sizeMax: 128
+    property int sizeValid: 0
+    property int startIndex: 0
 
-    onPointsChanged: graphCanvas.requestPaint()
+    onNewValueChanged: graphCanvas.requestPaint()
 
     property color strokeColor: "#fff"
 
     anchors.fill: parent
 
     Canvas {
+        // add recent value
+
         id: graphCanvas
         anchors.fill: parent
 
         opacity: 0.5
 
         onPaint: {
+            if(sizeValid == sizeMax) {
+                // buffer is full
+
+                // index to write to is the previous start index
+                let index = startIndex;
+                // write new value
+                history[index] = newValue;
+                // increment start index
+                startIndex = (startIndex + 1) % sizeMax;
+            } else {
+                // buffer is not full yet
+
+                // index to write to is at start index offset by valid size
+                let index = (startIndex + sizeValid) % sizeMax;
+                // write new value
+                history[index] = newValue;
+                // increment valid size
+                sizeValid++;
+            }
+
             var ctx = getContext("2d");
             ctx.clearRect(0, 0, graphCanvas.width, graphCanvas.height);
             ctx.strokeStyle = strokeColor;
@@ -31,8 +54,8 @@ Item {
             for (var i = 0; i < sizeValid - 1; i++) {
                 var indexStart = (startIndex + sizeValid - 1 - i + sizeMax) % sizeMax;
                 var indexEnd = (startIndex + sizeValid - i + sizeMax) % sizeMax;
-                ctx.moveTo(graphCanvas.width - i * lX, (1.0 - points[indexStart]) * graphCanvas.height);
-                ctx.lineTo(graphCanvas.width - (i + 1) * lX, (1.0 - points[indexEnd]) * graphCanvas.height)
+                ctx.moveTo(graphCanvas.width - i * lX, (1.0 - history[indexStart]) * graphCanvas.height);
+                ctx.lineTo(graphCanvas.width - (i + 1) * lX, (1.0 - history[indexEnd]) * graphCanvas.height)
             }
             ctx.closePath();
             ctx.stroke();

--- a/DynamicLights/HistoryGraph.qml
+++ b/DynamicLights/HistoryGraph.qml
@@ -31,8 +31,8 @@ Item {
             for (var i = 0; i < sizeValid - 1; i++) {
                 var indexStart = (startIndex + sizeValid - 1 - i + sizeMax) % sizeMax;
                 var indexEnd = (startIndex + sizeValid - i + sizeMax) % sizeMax;
-                ctx.moveTo(graphCanvas.width - i * lX, points[indexStart] * graphCanvas.height);
-                ctx.lineTo(graphCanvas.width - (i + 1) * lX, points[indexEnd] * graphCanvas.height)
+                ctx.moveTo(graphCanvas.width - i * lX, (1.0 - points[indexStart]) * graphCanvas.height);
+                ctx.lineTo(graphCanvas.width - (i + 1) * lX, (1.0 - points[indexEnd]) * graphCanvas.height)
             }
             ctx.closePath();
             ctx.stroke();

--- a/DynamicLights/HistoryGraph.qml
+++ b/DynamicLights/HistoryGraph.qml
@@ -9,7 +9,27 @@ Item {
     property int sizeValid: 0
     property int startIndex: 0
 
-    onNewValueChanged: graphCanvas.requestPaint()
+    onNewValueChanged: {
+        if(sizeValid == sizeMax) {
+            // buffer is full
+
+            // index to write to is the previous start index
+            let index = startIndex;
+            // write new value
+            history[index] = newValue;
+            // increment start index
+            startIndex = (startIndex + 1) % sizeMax;
+        } else {
+            // buffer is not full yet
+
+            // index to write to is at start index offset by valid size
+            let index = (startIndex + sizeValid) % sizeMax;
+            // write new value
+            history[index] = newValue;
+            // increment valid size
+            sizeValid++;
+        }
+    }
 
     property color strokeColor: "#fff"
 
@@ -23,27 +43,9 @@ Item {
 
         opacity: 0.5
 
-        onPaint: {
-            if(sizeValid == sizeMax) {
-                // buffer is full
+        onAvailableChanged: if(available) drawGraph()
 
-                // index to write to is the previous start index
-                let index = startIndex;
-                // write new value
-                history[index] = newValue;
-                // increment start index
-                startIndex = (startIndex + 1) % sizeMax;
-            } else {
-                // buffer is not full yet
-
-                // index to write to is at start index offset by valid size
-                let index = (startIndex + sizeValid) % sizeMax;
-                // write new value
-                history[index] = newValue;
-                // increment valid size
-                sizeValid++;
-            }
-
+        function drawGraph() {
             var ctx = getContext("2d");
             ctx.clearRect(0, 0, graphCanvas.width, graphCanvas.height);
             ctx.strokeStyle = strokeColor;
@@ -59,6 +61,8 @@ Item {
             }
             ctx.closePath();
             ctx.stroke();
+
+            requestAnimationFrame(drawGraph);
         }
     }
 }

--- a/DynamicLights/HistoryGraph.qml
+++ b/DynamicLights/HistoryGraph.qml
@@ -1,0 +1,39 @@
+import QtQuick 2.0
+
+Item {
+    id: historyGraph
+
+    property int startIndex
+    property int sizeValid
+    property int sizeMax
+    property variant points
+
+    onStartIndexChanged: graphCanvas.requestPaint()
+
+    property color strokeColor: "#fff"
+
+    anchors.fill: parent
+
+    Canvas {
+        id: graphCanvas
+        anchors.fill: parent
+
+        opacity: 0.5
+
+        onPaint: {
+            var ctx = getContext("2d");
+            ctx.clearRect(0, 0, graphCanvas.width, graphCanvas.height);
+            ctx.strokeStyle = strokeColor;
+
+            var lX = graphCanvas.width / (sizeMax - 1);
+
+            ctx.beginPath();
+            for (var i = 0; i < sizeMax - 1; i++) {
+                ctx.moveTo(i * lX, points[(startIndex + i) % sizeMax] * graphCanvas.height);
+                ctx.lineTo((i + 1) * lX, points[(startIndex + i + 1) % sizeMax] * graphCanvas.height)
+            }
+            ctx.closePath();
+            ctx.stroke();
+        }
+    }
+}

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -443,10 +443,9 @@ void SpikingNet::applyFiring() {
     // apply soft-clamp on output group activation
     for(int i = 0; i < outputGroupSize; i++) {
         outputGroupActivation[i] = softKneePositive(outputGroupActivation[i], 0.8);
-    }
-    if(flagDebug) {
-        //qDebug() << "number of neurons firing: " << total << endl;
-        //qDebug() << "activation of group 0: " << outputGroupActivation[0] << endl;
+        if(flagDebug) {
+            qDebug() << "output group " << i << " activation: " << outputGroupActivation[i];
+        }
     }
 }
 

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -96,15 +96,10 @@ int main(int argc, char *argv[])
     qmlRegisterUncreatableType<NeuronType>("ca.hexagram.xmodal.dynamiclight", 1, 0, "NeuronType", "Cannot instanciate NeuronType.");
 
     // create generator list
-    QSharedPointer<Generator> spikingNet1 = QSharedPointer<Generator>(new SpikingNet());
-    QSharedPointer<Generator> spikingNet2 = QSharedPointer<Generator>(new SpikingNet());
-    QSharedPointer<Generator> spikingNet3 = QSharedPointer<Generator>(new SpikingNet());
-    QSharedPointer<Generator> spikingNet4 = QSharedPointer<Generator>(new SpikingNet());
+    QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet());
     QSharedPointer<QList<QSharedPointer<Generator>>> generators = QSharedPointer<QList<QSharedPointer<Generator>>>(new QList<QSharedPointer<Generator>>());
-    generators.get()->append(spikingNet1);
-    generators.get()->append(spikingNet2);
-    generators.get()->append(spikingNet3);
-    generators.get()->append(spikingNet4);
+    generators.get()->append(spikingNet);
+
 
     // create generator facade list
     QSharedPointer<QList<QSharedPointer<Facade>>> generatorFacades = QSharedPointer<QList<QSharedPointer<Facade>>>(new QList<QSharedPointer<Facade>>());

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -96,9 +96,15 @@ int main(int argc, char *argv[])
     qmlRegisterUncreatableType<NeuronType>("ca.hexagram.xmodal.dynamiclight", 1, 0, "NeuronType", "Cannot instanciate NeuronType.");
 
     // create generator list
-    QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet());
+    QSharedPointer<Generator> spikingNet1 = QSharedPointer<Generator>(new SpikingNet());
+    QSharedPointer<Generator> spikingNet2 = QSharedPointer<Generator>(new SpikingNet());
+    QSharedPointer<Generator> spikingNet3 = QSharedPointer<Generator>(new SpikingNet());
+    QSharedPointer<Generator> spikingNet4 = QSharedPointer<Generator>(new SpikingNet());
     QSharedPointer<QList<QSharedPointer<Generator>>> generators = QSharedPointer<QList<QSharedPointer<Generator>>>(new QList<QSharedPointer<Generator>>());
-    generators.get()->append(spikingNet);
+    generators.get()->append(spikingNet1);
+    generators.get()->append(spikingNet2);
+    generators.get()->append(spikingNet3);
+    generators.get()->append(spikingNet4);
 
     // create generator facade list
     QSharedPointer<QList<QSharedPointer<Facade>>> generatorFacades = QSharedPointer<QList<QSharedPointer<Facade>>>(new QList<QSharedPointer<Facade>>());

--- a/DynamicLights/qml.qrc
+++ b/DynamicLights/qml.qrc
@@ -2,6 +2,7 @@
     <qresource prefix="/">
         <file>DebugStack.qml</file>
         <file>GeneratorWidget.qml</file>
+        <file>HistoryGraph.qml</file>
         <file>main.qml</file>
         <file>OutputIndicator.qml</file>
         <file>qtquickcontrols2.conf</file>


### PR DESCRIPTION
This closes #8, and closes #107. The history of each generator is now shown over its label in the generators list.

<img width="1392" alt="Capture d’écran, le 2020-07-15 à 11 22 24" src="https://user-images.githubusercontent.com/26071296/87563716-8c9cdc00-c68d-11ea-8c86-56993a5f2bb5.png">

The current solution implements efficient data sharing between C++ and QML JS, and optimized data storage in JS using a circular buffer, however the performance is very far from optimal — it becomes unacceptable when a few generators are added. The bottleneck has been identified as the Canvas program that draws the graph — it would need to be rewritten using a shader for optimal performance. This was discussed in #107. Issue #118 was created to address this.