### PR TITLE
Implement OSC backend

### DIFF
--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -30,10 +30,10 @@ ComputeEngine::ComputeEngine(QSharedPointer<QList<QSharedPointer<Generator>>> ge
         qDebug() << "constructor (ComputeEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
-    this->generatorsList = generators;
+    this->generators = generators;
     generatorsHashMap = QSharedPointer<QHash<int, QSharedPointer<Generator>>>(new QHash<int, QSharedPointer<Generator>>);
 
-    for(QList<QSharedPointer<Generator>>::iterator it = generatorsList->begin(); it != generatorsList->end(); it++) {
+    for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
         // get generator info
         QSharedPointer<Generator> generator = *it;
         // create hash map entry
@@ -50,7 +50,7 @@ ComputeEngine::~ComputeEngine() {
         qDebug() << "destructor (ComputeEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
     }
 
-    for(QList<QSharedPointer<Generator>>::iterator it = generatorsList->begin(); it != generatorsList->end(); it++) {
+    for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
         // get generator info
         QSharedPointer<Generator> generator = *it;
         int id = generator->getId();
@@ -77,7 +77,7 @@ void ComputeEngine::recieveOscData(int id, QVariant data) {
 
 void ComputeEngine::start() {
     // first we need to send some signals to the osc engine to create senders and recievers
-    for(QList<QSharedPointer<Generator>>::iterator it = generatorsList->begin(); it != generatorsList->end(); it++) {
+    for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
         // get generator info
         QSharedPointer<Generator> generator = *it;
         int id = generator->getId();
@@ -120,7 +120,7 @@ void ComputeEngine::loop() {
     elapsedTimer.start();
 
     // do the computation
-    for(QList<QSharedPointer<Generator>>::iterator it = generatorsList->begin(); it != generatorsList->end(); it++) {
+    for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
         // do the actual computation
         (*it)->computeOutput(1.0 / frequency);
         // update the value of the output monitor

--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -66,12 +66,33 @@ void ComputeEngine::recieveOscData(int id, QVariantList data) {
     }
     QSharedPointer<Generator> generator = generatorsHashMap->value(id);
 
+    QList<QVariant> dataAsList = data;
+
+    int argumentsTotal = data.size();
+    int argumentsValid = 0;
+
+    for(int i = 0; i < generator->getInputSize(); i++) {
+        // set default to 0
+        double input = 0;
+        // check that the message's list is long enough
+        if(i < data.size()) {
+            // check the message's type can be cast to double
+            QMetaType::Type type = (QMetaType::Type) dataAsList.at(i).type();
+            if(type == QMetaType::Float || QMetaType::Double || QMetaType::Int || QMetaType::Long) {
+                input = dataAsList.at(i).toDouble();
+                argumentsValid++;
+            }
+        }
+        // write to input
+        generator->writeInput(input, i);
+    }
+
     if(flagDebug) {
         std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "recieveOscData (ComputeEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t genid = " << id << "\t data = " << data;
+        qDebug() << "recieveOscData (ComputeEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\tdata = " << data << "\t(" << argumentsValid << " of " << argumentsTotal << " valid)";
     }
 }
 

--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -97,22 +97,6 @@ void ComputeEngine::recieveOscData(int id, QVariantList data) {
 }
 
 void ComputeEngine::start() {
-    // first we need to send some signals to the osc engine to create senders and recievers
-    // this doesn't happen in the constructor because the osc engine / thread don't exist yet when the compute engine is created in the main thread
-    for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
-        // get generator info
-        QSharedPointer<Generator> generator = *it;
-        int id = generator->getId();
-        QString addressReceiver = generator->getOscInputAddress();
-        QString addressSenderHost = generator->getOscOutputAddressHost();
-        QString addressSenderTarget = generator->getOscOutputAddressTarget();
-        int portReceiver = generator->getOscInputPort();
-        int portSender = generator->getOscOutputPort();
-        // create osc sender and receiver
-        emit createOscReceiver(id, addressReceiver, portReceiver);
-        emit createOscSender(id, addressSenderHost, addressSenderTarget, portSender);
-    }
-
     // this is called from an external thread initially and allows this object's thread to pick up the loop statement through its event queue
     // having a singleshot timer with time zero executes as soon as possible
     QTimer timer;

--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -154,12 +154,15 @@ void ComputeEngine::loop() {
     // measure the time used to do the computation
     millisCompute = elapsedTimer.nsecsElapsed() / 1000000.0;
 
-    if(flagDebug) {
-        qDebug() << "compute refresh interval: " << millisLastFrame;
-        qDebug() << "compute time:             " << millisCompute;
-    }
-
     QTimer timer;
     timer.setTimerType(Qt::PreciseTimer);
     timer.singleShot((int) std::min<double>(1.0 / frequency * 1000.0, std::max<double>(1.0 / frequency * 1000.0 - millisCompute, 0)), this, &ComputeEngine::loop);
+
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "loop (ComputeEngine):\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\trefresh (ms) = " << millisLastFrame << "\tcompute (ms) = " << millisCompute;
+    }
 }

--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -123,7 +123,10 @@ void ComputeEngine::loop() {
     for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
         // do the actual computation
         (*it)->computeOutput(1.0 / frequency);
-        // update the value of the output monitor
+    }
+
+    // write to outputMonitor
+    for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
         double outputMonitor = 0;
         for(int i = 0; i < (*it)->getOutputSize(); i++) {
             outputMonitor += (*it)->readOutput(i);
@@ -135,8 +138,17 @@ void ComputeEngine::loop() {
             // dumb averaging
             outputMonitor /= (*it)->getOutputSize();
         }
-
         (*it)->writeOutputMonitor(outputMonitor);
+    }
+
+    // send output messages to osc engine
+    for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
+        double * outputs = new double[(*it)->getOutputSize()];
+        for(int i = 0; i < (*it)->getOutputSize(); i++) {
+            outputs[i] = (*it)->readOutput(i);
+        }
+        emit sendOscData((*it)->getId(), QVariant(*outputs));
+        delete[] outputs;
     }
 
     // measure the time used to do the computation

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -19,6 +19,7 @@
 #include <QTimer>
 #include <QElapsedTimer>
 #include <QList>
+#include <QHash>
 #include <QSharedPointer>
 #include <random>
 #include "Generator.h"
@@ -28,6 +29,7 @@ class ComputeEngine : public QObject {
     Q_OBJECT
 private:
     QSharedPointer<QList<QSharedPointer<Generator>>> generators;
+    QSharedPointer<QHash<int, QSharedPointer<Generator>>> generatorsHashMap;
     QElapsedTimer elapsedTimer;
     double frequency = 80;
     bool firstFrame = true;
@@ -39,7 +41,19 @@ std::uniform_real_distribution<> randomUniform;
 public:
     ComputeEngine(QSharedPointer<QList<QSharedPointer<Generator>>> generators);
     ~ComputeEngine();
+signals:
+    void sendOscData(int id, QVariant data);
+
+    void createOscReceiver(int id, QString address, int port);
+    void updateOscReceiver(int id, QString address, int port);
+    void deleteOscReceiver(int id);
+
+    void createOscSender(int id, QString addressHost, QString addressTarget, int port);
+    void updateOscSender(int id, QString addressHost, QString addressTarget, int port);
+    void deleteOscSender(int id);
 public slots:
     void start();
     void loop();
+
+    void recieveOscData(int id, QVariant data);
 };

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -33,7 +33,7 @@ private:
     QElapsedTimer elapsedTimer;
     double frequency = 1;
     bool firstFrame = true;
-    bool flagDebug = true;
+    bool flagDebug = false;
     bool flagDummyOutputMonitor = false;
     bool flagDummyOscOutput = true;
     bool flagDisableProcessing = false;

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -31,7 +31,7 @@ private:
     QSharedPointer<QList<QSharedPointer<Generator>>> generators;
     QSharedPointer<QHash<int, QSharedPointer<Generator>>> generatorsHashMap;
     QElapsedTimer elapsedTimer;
-    double frequency = 80;
+    double frequency = 1;
     bool firstFrame = true;
     bool flagDebug = true;
     bool flagDummyOutputMonitor = false;

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -31,7 +31,7 @@ private:
     QSharedPointer<QList<QSharedPointer<Generator>>> generators;
     QSharedPointer<QHash<int, QSharedPointer<Generator>>> generatorsHashMap;
     QElapsedTimer elapsedTimer;
-    double frequency = 1;
+    double frequency = 60;
     bool firstFrame = true;
     bool flagDebug = false;
     bool flagDummyOutputMonitor = false;

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -35,7 +35,7 @@ private:
     bool firstFrame = true;
     bool flagDebug = false;
     bool flagDummyOutputMonitor = false;
-    bool flagDummyOscOutput = true;
+    bool flagDummyOscOutput = false;
     bool flagDisableProcessing = false;
     std::mt19937 randomGenerator;
 std::uniform_real_distribution<> randomUniform;

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -35,6 +35,7 @@ private:
     bool firstFrame = true;
     bool flagDebug = true;
     bool flagDummyOutputMonitor = false;
+    bool flagDummyOscOutput = true;
     bool flagDisableProcessing = false;
     std::mt19937 randomGenerator;
 std::uniform_real_distribution<> randomUniform;
@@ -42,7 +43,7 @@ public:
     ComputeEngine(QSharedPointer<QList<QSharedPointer<Generator>>> generators);
     ~ComputeEngine();
 signals:
-    void sendOscData(int id, QVariant data);
+    void sendOscData(int id, QVariantList data);
 
     void createOscReceiver(int id, QString address, int port);
     void updateOscReceiver(int id, QString address, int port);
@@ -55,5 +56,5 @@ public slots:
     void start();
     void loop();
 
-    void recieveOscData(int id, QVariant data);
+    void recieveOscData(int id, QVariantList data);
 };

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -33,7 +33,7 @@ private:
     QElapsedTimer elapsedTimer;
     double frequency = 80;
     bool firstFrame = true;
-    bool flagDebug = false;
+    bool flagDebug = true;
     bool flagDummyOutputMonitor = false;
     bool flagDisableProcessing = false;
     std::mt19937 randomGenerator;

--- a/DynamicLights/DebugStack.qml
+++ b/DynamicLights/DebugStack.qml
@@ -36,46 +36,4 @@ StackLayout {
             }
         }
     }
-
-    // OSC debug layout:
-    ColumnLayout {
-        RowLayout {
-            SpinBox {
-                id: someInt
-                value: 2
-            }
-            Slider {
-                id: someDouble
-                value: 3.14159
-                from: 0.0
-                to: 5.0
-            }
-            TextField {
-                id: someText
-                text: "hello"
-            }
-        }
-
-        Button {
-            text: "Send OSC"
-            font.strikeout: false
-            font.underline: false
-            font.bold: false
-            font.family: "Avenir Next Cyr Medium"
-            checked: false
-            checkable: false
-            onClicked: {
-                oscSender.send("/hello", [someInt.value, someDouble.value, someText.text]);
-            }
-        }
-
-        RowLayout {
-            Label {
-                text: "Received:"
-            }
-            Label {
-                text: lastMessageReceived
-            }
-        }
-    }
 }

--- a/DynamicLights/DynamicLights.pro
+++ b/DynamicLights/DynamicLights.pro
@@ -30,6 +30,7 @@ SOURCES += \
     Generator.cpp \
     GeneratorModel.cpp \
     Izhikevich.cpp \
+    OscEngine.cpp \
     SpikingNet.cpp \
     main.cpp
 
@@ -63,6 +64,7 @@ HEADERS += \
     GeneratorModel.h \
     Izhikevich.h \
     NeuronType.h \
+    OscEngine.h \
     SpikingNet.h
 
 INCLUDEPATH += $$PWD/../qosc

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -195,6 +195,7 @@ void Generator::writeOscInputPort(int oscInputPort) {
     this->oscInputPort = oscInputPort;
     emit valueChanged("oscInputPort", QVariant(oscInputPort));
     emit oscInputPortChanged(oscInputPort);
+    emit oscInputUpdated(oscInputAddress, oscInputPort);
 }
 
 void Generator::writeOscInputAddress(QString oscInputAddress) {
@@ -213,6 +214,7 @@ void Generator::writeOscInputAddress(QString oscInputAddress) {
     this->oscInputAddress = oscInputAddress;
     emit valueChanged("oscInputAddress", QVariant(oscInputAddress));
     emit oscInputAddressChanged(oscInputAddress);
+    emit oscInputUpdated(oscInputAddress, oscInputPort);
 }
 
 void Generator::writeOscOutputPort(int oscOutputPort) {
@@ -231,6 +233,7 @@ void Generator::writeOscOutputPort(int oscOutputPort) {
     this->oscOutputPort = oscOutputPort;
     emit valueChanged("oscOutputPort", QVariant(oscOutputPort));
     emit oscOutputPortChanged(oscOutputPort);
+    emit oscOutputUpdated(oscOutputAddressHost, oscOutputAddressTarget, oscInputPort);
 }
 
 void Generator::writeOscOutputAddressHost(QString oscOutputAddressHost) {
@@ -249,6 +252,7 @@ void Generator::writeOscOutputAddressHost(QString oscOutputAddressHost) {
     this->oscOutputAddressHost = oscOutputAddressHost;
     emit valueChanged("oscOutputAddressHost", QVariant(oscOutputAddressHost));
     emit oscOutputAddressHostChanged(oscOutputAddressHost);
+    emit oscOutputUpdated(oscOutputAddressHost, oscOutputAddressTarget, oscInputPort);
 }
 
 void Generator::writeOscOutputAddressTarget(QString oscOutputAddressTarget) {
@@ -267,6 +271,7 @@ void Generator::writeOscOutputAddressTarget(QString oscOutputAddressTarget) {
     this->oscOutputAddressTarget = oscOutputAddressTarget;
     emit valueChanged("oscOutputAddressTarget", QVariant(oscOutputAddressTarget));
     emit oscOutputAddressTargetChanged(oscOutputAddressTarget);
+    emit oscOutputUpdated(oscOutputAddressHost, oscOutputAddressTarget, oscInputPort);
 }
 
 void Generator::updateValue(const QString &key, const QVariant &value) {

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -73,8 +73,28 @@ double Generator::getOutputMonitor() {
     return outputMonitor;
 }
 
-void Generator::writeName(QString string) {
-    if(name == string) {
+int Generator::getOscInputPort() {
+    return oscInputPort;
+}
+
+QString Generator::getOscInputAddress() {
+    return oscInputAddress;
+}
+
+int Generator::getOscOutputPort() {
+    return oscOutputPort;
+}
+
+QString Generator::getOscOutputAddressHost() {
+    return oscOutputAddressHost;
+}
+
+QString Generator::getOscOutputAddressTarget() {
+    return oscOutputAddressTarget;
+}
+
+void Generator::writeName(QString name) {
+    if(this->name == name) {
         return;
     }
 
@@ -83,16 +103,16 @@ void Generator::writeName(QString string) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeName\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << string;
+        qDebug() << "writeName\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << name;
     }
 
-    name = string;
-    emit valueChanged("name", QVariant(string));
+    this->name = name;
+    emit valueChanged("name", QVariant(name));
     emit nameChanged(name);
 }
 
-void Generator::writeType(QString string) {
-    if(type == string) {
+void Generator::writeType(QString type) {
+    if(this->type == type) {
         return;
     }
 
@@ -101,16 +121,16 @@ void Generator::writeType(QString string) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeType\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << string;
+        qDebug() << "writeType\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << type;
     }
 
-    type = string;
-    emit valueChanged("type", QVariant(string));
+    this->type = type;
+    emit valueChanged("type", QVariant(type));
     emit typeChanged(type);
 }
 
-void Generator::writeDescription(QString string) {
-    if(description == string) {
+void Generator::writeDescription(QString description) {
+    if(this->description == description) {
         return;
     }
 
@@ -119,16 +139,16 @@ void Generator::writeDescription(QString string) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeDescription\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << string;
+        qDebug() << "writeDescription\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << description;
     }
 
-    description = string;
-    emit valueChanged("description", QVariant(string));
-    emit descriptionChanged(string);
+    this->description = description;
+    emit valueChanged("description", QVariant(description));
+    emit descriptionChanged(description);
 }
 
-void Generator::writeOutputMonitor(double value) {
-    if(outputMonitor == value) {
+void Generator::writeOutputMonitor(double outputMonitor) {
+    if(this->outputMonitor == outputMonitor) {
         return;
     }
 
@@ -137,13 +157,102 @@ void Generator::writeOutputMonitor(double value) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeOutputMonitor\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << value;
+        qDebug() << "writeOutputMonitor\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << outputMonitor;
     }
 
-    outputMonitor = value;
-
-    emit valueChanged("outputMonitor", QVariant(value));
+    this->outputMonitor = outputMonitor;
+    emit valueChanged("outputMonitor", QVariant(outputMonitor));
     emit outputMonitorChanged(outputMonitor);
+}
+
+void Generator::writeOscInputPort(int oscInputPort) {
+    if(this->oscInputPort == oscInputPort) {
+        return;
+    }
+
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "writeOscInputPort\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscInputPort;
+    }
+
+    this->oscInputPort = oscInputPort;
+    emit valueChanged("oscInputPort", QVariant(oscInputPort));
+    emit oscInputPortChanged(oscInputPort);
+}
+
+void Generator::writeOscInputAddress(QString oscInputAddress) {
+    if(this->oscInputAddress == oscInputAddress) {
+        return;
+    }
+
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "writeOscInputAddress\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscInputAddress;
+    }
+
+    this->oscInputAddress = oscInputAddress;
+    emit valueChanged("oscInputAddress", QVariant(oscInputAddress));
+    emit oscInputAddressChanged(oscInputAddress);
+}
+
+void Generator::writeOscOutputPort(int oscOutputPort) {
+    if(this->oscOutputPort == oscOutputPort) {
+        return;
+    }
+
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "writeOscOutputPort\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscOutputPort;
+    }
+
+    this->oscOutputPort = oscOutputPort;
+    emit valueChanged("oscOutputPort", QVariant(oscOutputPort));
+    emit oscOutputPortChanged(oscOutputPort);
+}
+
+void Generator::writeOscOutputAddressHost(QString oscOutputAddressHost) {
+    if(this->oscOutputAddressHost == oscOutputAddressHost) {
+        return;
+    }
+
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "writeOscOutputAddressHost\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscOutputAddressHost;
+    }
+
+    this->oscOutputAddressHost = oscOutputAddressHost;
+    emit valueChanged("oscOutputAddressHost", QVariant(oscOutputAddressHost));
+    emit oscOutputAddressHostChanged(oscOutputAddressHost);
+}
+
+void Generator::writeOscOutputAddressTarget(QString oscOutputAddressTarget) {
+    if(this->oscOutputAddressTarget == oscOutputAddressTarget) {
+        return;
+    }
+
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "writeOscOutputAddressTarget\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscOutputAddressTarget;
+    }
+
+    this->oscOutputAddressTarget = oscOutputAddressTarget;
+    emit valueChanged("oscOutputAddressTarget", QVariant(oscOutputAddressTarget));
+    emit oscOutputAddressTargetChanged(oscOutputAddressTarget);
 }
 
 void Generator::updateValue(const QString &key, const QVariant &value) {

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -44,6 +44,14 @@ Generator::~Generator() {
 }
 
 void Generator::writeInput(double value, int index) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "writeInput (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\tinid = " << index << "\tvalue = " << value;
+    }
+
     input[index] = value;
 }
 

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -20,13 +20,15 @@
 #include <QThread>
 #include <QDebug>
 
-Generator::Generator(QObject *parent) : QObject(parent) {
+Generator::Generator(int id) {
+    this->id = id;
+
     if(flagDebug) {
         std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "constructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+        qDebug() << "constructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id;
     }
 }
 
@@ -37,7 +39,7 @@ Generator::~Generator() {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "destructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+        qDebug() << "destructor (Generator)\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id;
     }
 }
 
@@ -55,6 +57,10 @@ int Generator::getInputSize() {
 
 int Generator::getOutputSize() {
     return output.size();
+}
+
+int Generator::getId() {
+    return id;
 }
 
 QString Generator::getName() {
@@ -103,7 +109,7 @@ void Generator::writeName(QString name) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeName\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << name;
+        qDebug() << "writeName\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << name;
     }
 
     this->name = name;
@@ -121,7 +127,7 @@ void Generator::writeType(QString type) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeType\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << type;
+        qDebug() << "writeType\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << type;
     }
 
     this->type = type;
@@ -139,7 +145,7 @@ void Generator::writeDescription(QString description) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeDescription\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << description;
+        qDebug() << "writeDescription\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << description;
     }
 
     this->description = description;
@@ -157,7 +163,7 @@ void Generator::writeOutputMonitor(double outputMonitor) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeOutputMonitor\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << outputMonitor;
+        qDebug() << "writeOutputMonitor\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << outputMonitor;
     }
 
     this->outputMonitor = outputMonitor;
@@ -175,7 +181,7 @@ void Generator::writeOscInputPort(int oscInputPort) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeOscInputPort\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscInputPort;
+        qDebug() << "writeOscInputPort\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << oscInputPort;
     }
 
     this->oscInputPort = oscInputPort;
@@ -193,7 +199,7 @@ void Generator::writeOscInputAddress(QString oscInputAddress) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeOscInputAddress\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscInputAddress;
+        qDebug() << "writeOscInputAddress\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << oscInputAddress;
     }
 
     this->oscInputAddress = oscInputAddress;
@@ -211,7 +217,7 @@ void Generator::writeOscOutputPort(int oscOutputPort) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeOscOutputPort\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscOutputPort;
+        qDebug() << "writeOscOutputPort\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << oscOutputPort;
     }
 
     this->oscOutputPort = oscOutputPort;
@@ -229,7 +235,7 @@ void Generator::writeOscOutputAddressHost(QString oscOutputAddressHost) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeOscOutputAddressHost\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscOutputAddressHost;
+        qDebug() << "writeOscOutputAddressHost\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << oscOutputAddressHost;
     }
 
     this->oscOutputAddressHost = oscOutputAddressHost;
@@ -247,7 +253,7 @@ void Generator::writeOscOutputAddressTarget(QString oscOutputAddressTarget) {
             std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "writeOscOutputAddressTarget\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\t value = " << oscOutputAddressTarget;
+        qDebug() << "writeOscOutputAddressTarget\t\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\t value = " << oscOutputAddressTarget;
     }
 
     this->oscOutputAddressTarget = oscOutputAddressTarget;

--- a/DynamicLights/Generator.cpp
+++ b/DynamicLights/Generator.cpp
@@ -195,7 +195,6 @@ void Generator::writeOscInputPort(int oscInputPort) {
     this->oscInputPort = oscInputPort;
     emit valueChanged("oscInputPort", QVariant(oscInputPort));
     emit oscInputPortChanged(oscInputPort);
-    emit oscInputUpdated(oscInputAddress, oscInputPort);
 }
 
 void Generator::writeOscInputAddress(QString oscInputAddress) {
@@ -214,7 +213,6 @@ void Generator::writeOscInputAddress(QString oscInputAddress) {
     this->oscInputAddress = oscInputAddress;
     emit valueChanged("oscInputAddress", QVariant(oscInputAddress));
     emit oscInputAddressChanged(oscInputAddress);
-    emit oscInputUpdated(oscInputAddress, oscInputPort);
 }
 
 void Generator::writeOscOutputPort(int oscOutputPort) {
@@ -233,7 +231,6 @@ void Generator::writeOscOutputPort(int oscOutputPort) {
     this->oscOutputPort = oscOutputPort;
     emit valueChanged("oscOutputPort", QVariant(oscOutputPort));
     emit oscOutputPortChanged(oscOutputPort);
-    emit oscOutputUpdated(oscOutputAddressHost, oscOutputAddressTarget, oscInputPort);
 }
 
 void Generator::writeOscOutputAddressHost(QString oscOutputAddressHost) {
@@ -252,7 +249,6 @@ void Generator::writeOscOutputAddressHost(QString oscOutputAddressHost) {
     this->oscOutputAddressHost = oscOutputAddressHost;
     emit valueChanged("oscOutputAddressHost", QVariant(oscOutputAddressHost));
     emit oscOutputAddressHostChanged(oscOutputAddressHost);
-    emit oscOutputUpdated(oscOutputAddressHost, oscOutputAddressTarget, oscInputPort);
 }
 
 void Generator::writeOscOutputAddressTarget(QString oscOutputAddressTarget) {
@@ -271,7 +267,6 @@ void Generator::writeOscOutputAddressTarget(QString oscOutputAddressTarget) {
     this->oscOutputAddressTarget = oscOutputAddressTarget;
     emit valueChanged("oscOutputAddressTarget", QVariant(oscOutputAddressTarget));
     emit oscOutputAddressTargetChanged(oscOutputAddressTarget);
-    emit oscOutputUpdated(oscOutputAddressHost, oscOutputAddressTarget, oscInputPort);
 }
 
 void Generator::updateValue(const QString &key, const QVariant &value) {

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -97,7 +97,7 @@ public:
     void writeOscOutputAddressHost(QString oscOutputAddressHost);
     void writeOscOutputAddressTarget(QString oscOutputAddressTarget);
 private:
-    bool flagDebug = false;
+    bool flagDebug = true;
 public slots:
     // common slot allowing to update any property. allows the Facade class to work properly
     // (for connection from QQmlPropertyMap's valueChanged signal)

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -49,12 +49,12 @@ protected:
     QString description;            // generator description, fixed
     double outputMonitor;           // output monitor / indicator light, generated from output array automatically by ComputeEngine
 
-    int oscInputPort;               // generator osc input port, assigned by user
-    QString oscInputAddress;        // generator osc input address, assigned by user
+    int oscInputPort = 6668;                    // generator osc input port, assigned by user
+    QString oscInputAddress = "/input";         // generator osc input address, assigned by user
 
-    int oscOutputPort;              // generator osc output port, assigned by user
-    QString oscOutputAddressHost;   // generator osc output address for host, assigned by user
-    QString oscOutputAddressTarget; // generator osc output address for target, assigned by user
+    int oscOutputPort = 6669;                   // generator osc output port, assigned by user
+    QString oscOutputAddressHost = "127.0.0.1"; // generator osc output address for host, assigned by user
+    QString oscOutputAddressTarget = "/output"; // generator osc output address for target, assigned by user
 public:
     Generator(int id);
     ~Generator();

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -119,8 +119,4 @@ signals:
     void oscOutputPortChanged(int oscOutputPort);
     void oscOutputAddressHostChanged(QString oscOutputAddressHost);
     void oscOutputAddressTargetChanged(QString oscOutputAddressTarget);
-
-    // signals for updating osc engine
-    void oscInputUpdated(QString oscInputAddress, int oscInputPort);
-    void oscOutputUpdated(QString oscOutputAddressHost, QString oscOutputAddressTarget, int oscOutputPort);
 };

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -50,11 +50,11 @@ protected:
     double outputMonitor;           // output monitor / indicator light, generated from output array automatically by ComputeEngine
 
     int oscInputPort = 6668;                    // generator osc input port, assigned by user
-    QString oscInputAddress = "/input";         // generator osc input address, assigned by user
+    QString oscInputAddress = "/input";         // generator osc input address, assigned by user (this is an osc destination)
 
     int oscOutputPort = 6669;                   // generator osc output port, assigned by user
-    QString oscOutputAddressHost = "127.0.0.1"; // generator osc output address for host, assigned by user
-    QString oscOutputAddressTarget = "/output"; // generator osc output address for target, assigned by user
+    QString oscOutputAddressHost = "127.0.0.1"; // generator osc output address for host, assigned by user (this is an ip)
+    QString oscOutputAddressTarget = "/output"; // generator osc output address for target, assigned by user (this is an osc destination)
 public:
     Generator(int id);
     ~Generator();
@@ -108,15 +108,19 @@ signals:
     void valueChanged(const QString &key, const QVariant &value);
 
     // usual signals for property changes
-    void nameChanged(QString);
-    void typeChanged(QString);
-    void descriptionChanged(QString);
-    void outputMonitorChanged(double);
+    void nameChanged(QString name);
+    void typeChanged(QString type);
+    void descriptionChanged(QString description);
+    void outputMonitorChanged(double outputMonitor);
 
-    void oscInputPortChanged(int);
-    void oscInputAddressChanged(QString);
+    void oscInputPortChanged(int oscInputPort);
+    void oscInputAddressChanged(QString oscInputAddress);
 
-    void oscOutputPortChanged(int);
-    void oscOutputAddressHostChanged(QString);
-    void oscOutputAddressTargetChanged(QString);
+    void oscOutputPortChanged(int oscOutputPort);
+    void oscOutputAddressHostChanged(QString oscOutputAddressHost);
+    void oscOutputAddressTargetChanged(QString oscOutputAddressTarget);
+
+    // signals for updating osc engine
+    void oscInputUpdated(QString oscInputAddress, int oscInputPort);
+    void oscOutputUpdated(QString oscOutputAddressHost, QString oscOutputAddressTarget, int oscOutputPort);
 };

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -97,7 +97,7 @@ public:
     void writeOscOutputAddressHost(QString oscOutputAddressHost);
     void writeOscOutputAddressTarget(QString oscOutputAddressTarget);
 private:
-    bool flagDebug = true;
+    bool flagDebug = false;
 public slots:
     // common slot allowing to update any property. allows the Facade class to work properly
     // (for connection from QQmlPropertyMap's valueChanged signal)

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -41,20 +41,22 @@ protected:
     std::vector<double> input;
     std::vector<double> output;
 
+    int id;                         // generator id, generated automatically by ComputeEngine in constructor
+
     // descriptive properties seen in the generators list panel
-    QString name;           // generator name, assigned by user
-    QString type;           // generator type, fixed
-    QString description;    // generator description, fixed
-    double outputMonitor;   // output monitor / indicator light, generated from output array automatically by ComputeEngine
+    QString name;                   // generator name, assigned by user
+    QString type;                   // generator type, fixed
+    QString description;            // generator description, fixed
+    double outputMonitor;           // output monitor / indicator light, generated from output array automatically by ComputeEngine
 
-    int oscInputPort;
-    QString oscInputAddress;
+    int oscInputPort;               // generator osc input port, assigned by user
+    QString oscInputAddress;        // generator osc input address, assigned by user
 
-    int oscOutputPort;
-    QString oscOutputAddressHost;
-    QString oscOutputAddressTarget;
+    int oscOutputPort;              // generator osc output port, assigned by user
+    QString oscOutputAddressHost;   // generator osc output address for host, assigned by user
+    QString oscOutputAddressTarget; // generator osc output address for target, assigned by user
 public:
-    explicit Generator(QObject *parent = nullptr);
+    Generator(int id);
     ~Generator();
 
     // the method implemented by the derived class that computes the output
@@ -65,6 +67,9 @@ public:
     double readOutput(int index);
     int getInputSize();
     int getOutputSize();
+
+    // method for reading id
+    int getId();
 
     // methods to read properties
     QString getName();

--- a/DynamicLights/Generator.h
+++ b/DynamicLights/Generator.h
@@ -29,6 +29,13 @@ class Generator : public QObject
     Q_PROPERTY(QString type READ getType NOTIFY typeChanged)
     Q_PROPERTY(QString description READ getDescription WRITE writeDescription NOTIFY descriptionChanged)
     Q_PROPERTY(double outputMonitor READ getOutputMonitor NOTIFY outputMonitorChanged)
+
+    Q_PROPERTY(int oscInputPort READ getOscInputPort WRITE writeOscInputPort NOTIFY oscInputPortChanged)
+    Q_PROPERTY(QString oscInputAddress READ getOscInputAddress WRITE writeOscInputAddress NOTIFY oscInputAddressChanged)
+
+    Q_PROPERTY(int oscOutputPort READ getOscOutputPort WRITE writeOscOutputPort NOTIFY oscOutputPortChanged)
+    Q_PROPERTY(QString oscOutputAddressHost READ getOscOutputAddressHost WRITE writeOscOutputAddressHost NOTIFY oscOutputAddressHostChanged)
+    Q_PROPERTY(QString oscOutputAddressTarget READ getOscOutputAddressTarget WRITE writeOscOutputAddressTarget NOTIFY oscOutputAddressTargetChanged)
 protected:
     // the generator class provides input and output buffers
     std::vector<double> input;
@@ -40,22 +47,12 @@ protected:
     QString description;    // generator description, fixed
     double outputMonitor;   // output monitor / indicator light, generated from output array automatically by ComputeEngine
 
-    // example for indexing outputMonitorHistory:
+    int oscInputPort;
+    QString oscInputAddress;
 
-    // indexing chronologically (oldest to newest)
-    //
-    //  for(int i = 0; i < outputMonitorHistorySizeValid; i++) {
-    //      int index = (outputMonitorHistoryStartIndex + i) % outputMonitorHistorySizeMax;
-    //  }
-    //
-
-    // indexing reverse-chronologically (newest to oldest)
-    //
-    //  for(int i = 0; i < outputMonitorHistorySizeValid; i++) {
-    //      int index = (outputMonitorHistoryStartIndex + outputMonitorHistorySizeValid - 1 - i + outputMonitorHistorySizeMax) % outputMonitorHistorySizeMax;
-    //  }
-    //
-
+    int oscOutputPort;
+    QString oscOutputAddressHost;
+    QString oscOutputAddressTarget;
 public:
     explicit Generator(QObject *parent = nullptr);
     ~Generator();
@@ -69,24 +66,52 @@ public:
     int getInputSize();
     int getOutputSize();
 
-    // methods to read, write to descriptive properties seen in the generators list panel
+    // methods to read properties
     QString getName();
     QString getType();
     QString getDescription();
     double getOutputMonitor();
 
-    void writeName(QString string);
-    void writeType(QString string);
-    void writeDescription(QString string);
-    void writeOutputMonitor(double value);
+    int getOscInputPort();
+    QString getOscInputAddress();
+
+    int getOscOutputPort();
+    QString getOscOutputAddressHost();
+    QString getOscOutputAddressTarget();
+
+    // methods to write properties
+    void writeName(QString name);
+    void writeType(QString type);
+    void writeDescription(QString description);
+    void writeOutputMonitor(double outputMonitor);
+
+    void writeOscInputPort(int oscInputPort);
+    void writeOscInputAddress(QString oscInputAddress);
+
+    void writeOscOutputPort(int oscOutputPort);
+    void writeOscOutputAddressHost(QString oscOutputAddressHost);
+    void writeOscOutputAddressTarget(QString oscOutputAddressTarget);
 private:
     bool flagDebug = false;
 public slots:
-    void updateValue(const QString &key, const QVariant &value); // for connection from QQmlPropertyMap's valueChanged signal
+    // common slot allowing to update any property. allows the Facade class to work properly
+    // (for connection from QQmlPropertyMap's valueChanged signal)
+    void updateValue(const QString &key, const QVariant &value);
 signals:
-    void valueChanged(const QString &key, const QVariant &value); // for connection to QQmlPropertyMap's updateValue slot
+    // common signal used alongside all other property change signals. allows the Facade class to work properly
+    // (for connection to QQmlPropertyMap's updateValue slot)
+    void valueChanged(const QString &key, const QVariant &value);
+
+    // usual signals for property changes
     void nameChanged(QString);
     void typeChanged(QString);
     void descriptionChanged(QString);
     void outputMonitorChanged(double);
+
+    void oscInputPortChanged(int);
+    void oscInputAddressChanged(QString);
+
+    void oscOutputPortChanged(int);
+    void oscOutputAddressHostChanged(QString);
+    void oscOutputAddressTargetChanged(QString);
 };

--- a/DynamicLights/OscEngine.cpp
+++ b/DynamicLights/OscEngine.cpp
@@ -114,28 +114,6 @@ void OscEngine::createOscReceiver(int id, QString address, int port) {
     connectReceiver(id);
 }
 
-void OscEngine::updateOscReceiver(int id, QString address, int port) {
-    if(flagDebug) {
-        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()
-        );
-
-        qDebug() << "updateOscReceiver (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddress = " << address << "\tport = " << port;
-    }
-
-    if(!oscReceivers.contains(id)) {
-        throw std::runtime_error("osc receiver does not exist");
-    }
-    // this is stupid. OscReceiver should be written to allow port changes, rather than having to destroy and create a new object
-    oscReceivers.remove(id);
-    QSharedPointer<OscReceiver> receiver = QSharedPointer<OscReceiver>(new OscReceiver(port));
-    // update hash maps
-    oscReceivers.insert(id, receiver);
-    oscReceiverAddresses.insert(id, address);
-    // connect reciever
-    connectReceiver(id);
-}
-
 void OscEngine::deleteOscReceiver(int id) {
     if(flagDebug) {
         std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -151,6 +129,36 @@ void OscEngine::deleteOscReceiver(int id) {
     // delete from hash maps
     oscReceivers.remove(id);
     oscReceiverAddresses.remove(id);
+}
+
+void OscEngine::updateOscReceiverAddress(int id, QString address) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "updateOscReceiverAddress (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddress = " << address;
+    }
+
+    if(!oscReceivers.contains(id)) {
+        throw std::runtime_error("osc receiver does not exist");
+    }
+    oscReceiverAddresses.insert(id, address);
+}
+
+void OscEngine::updateOscReceiverPort(int id, int port) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "updateOscReceiverPort (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\tport = " << port;
+    }
+
+    if(!oscReceivers.contains(id)) {
+        throw std::runtime_error("osc receiver does not exist");
+    }
+    oscReceivers.value(id)->setPort(port);
 }
 
 void OscEngine::createOscSender(int id, QString addressHost, QString addressTarget, int port) {
@@ -171,32 +179,6 @@ void OscEngine::createOscSender(int id, QString addressHost, QString addressTarg
     oscSenderAddresses.insert(id, addressTarget);
 }
 
-void OscEngine::updateOscSender(int id, QString addressHost, QString addressTarget, int port) {
-    if(flagDebug) {
-        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
-                    std::chrono::system_clock::now().time_since_epoch()
-        );
-
-        qDebug() << "updateOscSender (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddressHost = " << addressHost << "\taddressTarget = " << addressTarget << "\tport = " << port;
-    }
-
-    deleteOscSender(id);
-    createOscSender(id, addressHost, addressTarget, port);
-
-    /*
-
-    if(!oscSenders.contains(id)) {
-        throw std::runtime_error("osc sender does not exist");
-    }
-    // this is stupid. OscSender should be written to allow port and address changes, rather than having to destroy and create a new object
-    oscSenders.remove(id);
-    QSharedPointer<OscSender> sender = QSharedPointer<OscSender>(new OscSender(addressHost, port));
-    // update hash maps
-    oscSenders.insert(id, sender);
-    oscSenderAddresses.insert(id, addressTarget);
-    */
-}
-
 void OscEngine::deleteOscSender(int id) {
     if(flagDebug) {
         std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
@@ -212,4 +194,49 @@ void OscEngine::deleteOscSender(int id) {
     // delete from hash maps
     oscSenders.remove(id);
     oscSenders.remove(id);
+}
+
+void OscEngine::updateOscSenderAddressHost(int id, QString addressHost) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "updateOscSenderAddressHost (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddressHost = " << addressHost;
+    }
+
+    if(!oscSenders.contains(id)) {
+        throw std::runtime_error("osc sender does not exist");
+    }
+    oscSenders.value(id)->setHostAddress(addressHost);
+}
+
+void OscEngine::updateOscSenderAddressTarget(int id, QString addressTarget) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "updateOscSenderAddressTarget (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddressTarget = " << addressTarget;
+    }
+
+    if(!oscSenders.contains(id)) {
+        throw std::runtime_error("osc sender does not exist");
+    }
+    oscSenderAddresses.insert(id, addressTarget);
+}
+
+void OscEngine::updateOscSenderPort(int id, int port) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "updateOscSenderPort (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\tport = " << port;
+    }
+
+    if(!oscSenders.contains(id)) {
+        throw std::runtime_error("osc receiver does not exist");
+    }
+    oscSenders.value(id)->setPort(port);
 }

--- a/DynamicLights/OscEngine.cpp
+++ b/DynamicLights/OscEngine.cpp
@@ -177,8 +177,13 @@ void OscEngine::updateOscSender(int id, QString addressHost, QString addressTarg
                     std::chrono::system_clock::now().time_since_epoch()
         );
 
-        qDebug() << "createOscSender (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddressHost = " << addressHost << "\taddressTarget = " << addressTarget << "\tport = " << port;
+        qDebug() << "updateOscSender (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddressHost = " << addressHost << "\taddressTarget = " << addressTarget << "\tport = " << port;
     }
+
+    deleteOscSender(id);
+    createOscSender(id, addressHost, addressTarget, port);
+
+    /*
 
     if(!oscSenders.contains(id)) {
         throw std::runtime_error("osc sender does not exist");
@@ -189,6 +194,7 @@ void OscEngine::updateOscSender(int id, QString addressHost, QString addressTarg
     // update hash maps
     oscSenders.insert(id, sender);
     oscSenderAddresses.insert(id, addressTarget);
+    */
 }
 
 void OscEngine::deleteOscSender(int id) {

--- a/DynamicLights/OscEngine.cpp
+++ b/DynamicLights/OscEngine.cpp
@@ -77,7 +77,7 @@ void OscEngine::recieveOscDataHandler(int id, const QString& oscAddress, const Q
     }
 }
 
-void OscEngine::sendOscData(int id, QVariant data) {
+void OscEngine::sendOscData(int id, QVariantList data) {
     if(flagDebug) {
         std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::system_clock::now().time_since_epoch()
@@ -90,6 +90,8 @@ void OscEngine::sendOscData(int id, QVariant data) {
         throw std::runtime_error("osc sender does not exist");
     }
     QSharedPointer<OscSender> sender = oscSenders.value(id);
+    QString address = oscSenderAddresses.value(id);
+    sender->send(address, data);
 }
 
 void OscEngine::createOscReceiver(int id, QString address, int port) {

--- a/DynamicLights/OscEngine.cpp
+++ b/DynamicLights/OscEngine.cpp
@@ -15,6 +15,193 @@
 
 #include "OscEngine.h"
 
-OscEngine::OscEngine() {
+#include <chrono>
+#include <QDebug>
+#include <QThread>
 
+OscEngine::OscEngine() {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "constructor (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+    }
+}
+
+OscEngine::~OscEngine() {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "destructor (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+    }
+}
+
+void OscEngine::connectReceiver(int id) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "connectReceiver (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id;
+    }
+
+    if(!oscReceivers.contains(id)) {
+        throw std::runtime_error("osc receiver does not exist");
+    }
+    QSharedPointer<OscReceiver> receiver = oscReceivers.value(id);
+
+    QObject::connect(receiver.data(), &OscReceiver::messageReceived, this, [this, id](const QString& oscAddress, const QVariantList& message){
+        recieveOscDataHandler(id, oscAddress, message);
+    });
+}
+
+void OscEngine::recieveOscDataHandler(int id, const QString& oscAddress, const QVariantList& message) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "recieveOscDataHandler (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddress = " << oscAddress << "\tmessage = " << message;
+    }
+
+    if(!oscReceivers.contains(id)) {
+        throw std::runtime_error("osc receiver does not exist");
+    }
+    QString oscAddressExpected = oscReceiverAddresses.value(id);
+    if(oscAddress == oscAddressExpected) {
+        // message recieved with right address
+        emit recieveOscData(id, message);
+    }
+}
+
+void OscEngine::sendOscData(int id, QVariant data) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "sendOscData (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\tmessage = " << data;
+    }
+
+    if(!oscSenders.contains(id)) {
+        throw std::runtime_error("osc sender does not exist");
+    }
+    QSharedPointer<OscSender> sender = oscSenders.value(id);
+}
+
+void OscEngine::createOscReceiver(int id, QString address, int port) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "createOscReceiver (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddress = " << address << "\tport = " << port;
+    }
+
+    if(oscReceivers.contains(id)) {
+        throw std::runtime_error("osc receiver already exists");
+    }
+    QSharedPointer<OscReceiver> receiver = QSharedPointer<OscReceiver>(new OscReceiver(port));
+    // update hash maps
+    oscReceivers.insert(id, receiver);
+    oscReceiverAddresses.insert(id, address);
+    // connect reciever
+    connectReceiver(id);
+}
+
+void OscEngine::updateOscReceiver(int id, QString address, int port) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "updateOscReceiver (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddress = " << address << "\tport = " << port;
+    }
+
+    if(!oscReceivers.contains(id)) {
+        throw std::runtime_error("osc receiver does not exist");
+    }
+    // this is stupid. OscReceiver should be written to allow port changes, rather than having to destroy and create a new object
+    oscReceivers.remove(id);
+    QSharedPointer<OscReceiver> receiver = QSharedPointer<OscReceiver>(new OscReceiver(port));
+    // update hash maps
+    oscReceivers.insert(id, receiver);
+    oscReceiverAddresses.insert(id, address);
+    // connect reciever
+    connectReceiver(id);
+}
+
+void OscEngine::deleteOscReceiver(int id) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "deleteOscReceiver (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id;
+    }
+
+    if(!oscReceivers.contains(id)) {
+        throw std::runtime_error("osc receiver does not exist");
+    }
+    // delete from hash maps
+    oscReceivers.remove(id);
+    oscReceiverAddresses.remove(id);
+}
+
+void OscEngine::createOscSender(int id, QString addressHost, QString addressTarget, int port) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "createOscSender (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddressHost = " << addressHost << "\taddressTarget = " << addressTarget << "\tport = " << port;
+    }
+
+    if(oscSenders.contains(id)) {
+        throw std::runtime_error("osc sender already exists");
+    }
+    QSharedPointer<OscSender> sender = QSharedPointer<OscSender>(new OscSender(addressHost, port));
+    // update hash maps
+    oscSenders.insert(id, sender);
+    oscSenderAddresses.insert(id, addressTarget);
+}
+
+void OscEngine::updateOscSender(int id, QString addressHost, QString addressTarget, int port) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "createOscSender (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id << "\taddressHost = " << addressHost << "\taddressTarget = " << addressTarget << "\tport = " << port;
+    }
+
+    if(!oscSenders.contains(id)) {
+        throw std::runtime_error("osc sender does not exist");
+    }
+    // this is stupid. OscSender should be written to allow port and address changes, rather than having to destroy and create a new object
+    oscSenders.remove(id);
+    QSharedPointer<OscSender> sender = QSharedPointer<OscSender>(new OscSender(addressHost, port));
+    // update hash maps
+    oscSenders.insert(id, sender);
+    oscSenderAddresses.insert(id, addressTarget);
+}
+
+void OscEngine::deleteOscSender(int id) {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "deleteOscSender (OscEngine):\tt = " << now.count() << "\tid = " << QThread::currentThreadId() << "\tgenid = " << id;
+    }
+
+    if(!oscSenders.contains(id)) {
+        throw std::runtime_error("osc sender does not exist");
+    }
+    // delete from hash maps
+    oscSenders.remove(id);
+    oscSenders.remove(id);
 }

--- a/DynamicLights/OscEngine.cpp
+++ b/DynamicLights/OscEngine.cpp
@@ -1,0 +1,20 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#include "OscEngine.h"
+
+OscEngine::OscEngine() {
+
+}

--- a/DynamicLights/OscEngine.h
+++ b/DynamicLights/OscEngine.h
@@ -34,7 +34,7 @@ private:
 
     void connectReceiver(int id);
 
-    bool flagDebug = true;
+    bool flagDebug = false;
 signals:
     void recieveOscData(int id, QVariantList data);
 public slots:

--- a/DynamicLights/OscEngine.h
+++ b/DynamicLights/OscEngine.h
@@ -25,19 +25,27 @@ class OscEngine : public QObject {
     Q_OBJECT
 public:
     OscEngine();
+    ~OscEngine();
 private:
     QHash<int, QSharedPointer<OscSender>> oscSenders;
-    QHash<int, QSharedPointer<OscReceiver>> oscRecievers;
+    QHash<int, QString> oscSenderAddresses;
+    QHash<int, QSharedPointer<OscReceiver>> oscReceivers;
+    QHash<int, QString> oscReceiverAddresses;
+
+    void connectReceiver(int id);
+
+    bool flagDebug = true;
 signals:
-    void dataRecieved(int, QVariant);
+    void recieveOscData(int id, QVariant data);
 public slots:
-    void sendData(int id, QVariant data);
+    void recieveOscDataHandler(int id, const QString& oscAddress, const QVariantList& message);
+    void sendOscData(int id, QVariant data);
 
-    void createReciever(int id, QString address, int port);
-    void updateReciever(int id, QString address, int port);
-    void deleteReciever(int id);
+    void createOscReceiver(int id, QString address, int port);
+    void updateOscReceiver(int id, QString address, int port);
+    void deleteOscReceiver(int id);
 
-    void createSender(int id, QString hostAddress, int port);
-    void updateSender(int id, QString hostAddress, int port);
-    void deleteSender(int id);
+    void createOscSender(int id, QString addressHost, QString addressTarget, int port);
+    void updateOscSender(int id, QString addressHost, QString addressTarget, int port);
+    void deleteOscSender(int id);
 };

--- a/DynamicLights/OscEngine.h
+++ b/DynamicLights/OscEngine.h
@@ -36,10 +36,10 @@ private:
 
     bool flagDebug = true;
 signals:
-    void recieveOscData(int id, QVariant data);
+    void recieveOscData(int id, QVariantList data);
 public slots:
     void recieveOscDataHandler(int id, const QString& oscAddress, const QVariantList& message);
-    void sendOscData(int id, QVariant data);
+    void sendOscData(int id, QVariantList data);
 
     void createOscReceiver(int id, QString address, int port);
     void updateOscReceiver(int id, QString address, int port);

--- a/DynamicLights/OscEngine.h
+++ b/DynamicLights/OscEngine.h
@@ -1,0 +1,27 @@
+// Copyright 2020, Xmodal
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+#pragma once
+
+#include <QObject>
+#include "OscSender.h"
+#include "OscReceiver.h"
+
+class OscEngine : public QObject {
+    Q_OBJECT
+public:
+    OscEngine();
+    // TODO: implement signal / slots to process incoming / outgoing messages
+};

--- a/DynamicLights/OscEngine.h
+++ b/DynamicLights/OscEngine.h
@@ -16,6 +16,8 @@
 #pragma once
 
 #include <QObject>
+#include <QSharedPointer>
+#include <QHash>
 #include "OscSender.h"
 #include "OscReceiver.h"
 
@@ -23,5 +25,19 @@ class OscEngine : public QObject {
     Q_OBJECT
 public:
     OscEngine();
-    // TODO: implement signal / slots to process incoming / outgoing messages
+private:
+    QHash<int, QSharedPointer<OscSender>> oscSenders;
+    QHash<int, QSharedPointer<OscReceiver>> oscRecievers;
+signals:
+    void dataRecieved(int, QVariant);
+public slots:
+    void sendData(int id, QVariant data);
+
+    void createReciever(int id, QString address, int port);
+    void updateReciever(int id, QString address, int port);
+    void deleteReciever(int id);
+
+    void createSender(int id, QString hostAddress, int port);
+    void updateSender(int id, QString hostAddress, int port);
+    void deleteSender(int id);
 };

--- a/DynamicLights/OscEngine.h
+++ b/DynamicLights/OscEngine.h
@@ -42,10 +42,13 @@ public slots:
     void sendOscData(int id, QVariantList data);
 
     void createOscReceiver(int id, QString address, int port);
-    void updateOscReceiver(int id, QString address, int port);
     void deleteOscReceiver(int id);
+    void updateOscReceiverAddress(int id, QString address);
+    void updateOscReceiverPort(int id, int port);
 
     void createOscSender(int id, QString addressHost, QString addressTarget, int port);
-    void updateOscSender(int id, QString addressHost, QString addressTarget, int port);
     void deleteOscSender(int id);
+    void updateOscSenderAddressHost(int id, QString addressHost);
+    void updateOscSenderAddressTarget(int id, QString addressHost);
+    void updateOscSenderPort(int id, int port);
 };

--- a/DynamicLights/SpikingNet.cpp
+++ b/DynamicLights/SpikingNet.cpp
@@ -21,7 +21,7 @@
 
 // ############################### initialization routines ###############################
 
-SpikingNet::SpikingNet() {
+SpikingNet::SpikingNet(int id) : Generator(id) {
     if(flagDebug) {
         std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
                     std::chrono::system_clock::now().time_since_epoch()

--- a/DynamicLights/SpikingNet.h
+++ b/DynamicLights/SpikingNet.h
@@ -152,7 +152,7 @@ private:
     double getOutputGroupActivation(int outputGroupIndex);
 
 public:
-    SpikingNet();
+    SpikingNet(int id);
     ~SpikingNet();
 
     void computeOutput(double deltaTime);

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -110,7 +110,19 @@ int main(int argc, char *argv[]) {
     // move osc engine to compute thread
     oscEngine.moveToThread(oscThread.get());
 
-    // TODO: connect compute engine to osc engine
+    // connect compute engine to osc engine
+    QObject::connect(&computeEngine, &ComputeEngine::sendOscData, &oscEngine, &OscEngine::sendOscData);
+
+    QObject::connect(&computeEngine, &ComputeEngine::createOscReceiver, &oscEngine, &OscEngine::createOscReceiver);
+    QObject::connect(&computeEngine, &ComputeEngine::updateOscReceiver, &oscEngine, &OscEngine::updateOscReceiver);
+    QObject::connect(&computeEngine, &ComputeEngine::deleteOscReceiver, &oscEngine, &OscEngine::deleteOscReceiver);
+
+    QObject::connect(&computeEngine, &ComputeEngine::createOscSender, &oscEngine, &OscEngine::createOscSender);
+    QObject::connect(&computeEngine, &ComputeEngine::updateOscSender, &oscEngine, &OscEngine::updateOscSender);
+    QObject::connect(&computeEngine, &ComputeEngine::deleteOscSender, &oscEngine, &OscEngine::deleteOscSender);
+
+    // connect osc engine to compute engine
+    QObject::connect(&oscEngine, &OscEngine::recieveOscData, &computeEngine, &ComputeEngine::recieveOscData);
 
     // start compute engine
     computeEngine.start();

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -63,11 +63,9 @@ int main(int argc, char *argv[]) {
     qmlRegisterUncreatableType<NeuronType>("ca.hexagram.xmodal.dynamiclight", 1, 0, "NeuronType", "Cannot instanciate NeuronType.");
 
     // create generator list
-    QSharedPointer<Generator> spikingNet1 = QSharedPointer<Generator>(new SpikingNet(0));
-    QSharedPointer<Generator> spikingNet2 = QSharedPointer<Generator>(new SpikingNet(1));
+    QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet(0));
     QSharedPointer<QList<QSharedPointer<Generator>>> generators = QSharedPointer<QList<QSharedPointer<Generator>>>(new QList<QSharedPointer<Generator>>());
-    generators.get()->append(spikingNet1);
-    generators.get()->append(spikingNet2);
+    generators.get()->append(spikingNet);
 
 
     // create generator facade list

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -61,9 +61,11 @@ int main(int argc, char *argv[]) {
     qmlRegisterUncreatableType<NeuronType>("ca.hexagram.xmodal.dynamiclight", 1, 0, "NeuronType", "Cannot instanciate NeuronType.");
 
     // create generator list
-    QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet(0));
+    QSharedPointer<Generator> spikingNet1 = QSharedPointer<Generator>(new SpikingNet(0));
+    QSharedPointer<Generator> spikingNet2 = QSharedPointer<Generator>(new SpikingNet(1));
     QSharedPointer<QList<QSharedPointer<Generator>>> generators = QSharedPointer<QList<QSharedPointer<Generator>>>(new QList<QSharedPointer<Generator>>());
-    generators.get()->append(spikingNet);
+    generators.get()->append(spikingNet1);
+    generators.get()->append(spikingNet2);
 
 
     // create generator facade list

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -61,7 +61,7 @@ int main(int argc, char *argv[]) {
     qmlRegisterUncreatableType<NeuronType>("ca.hexagram.xmodal.dynamiclight", 1, 0, "NeuronType", "Cannot instanciate NeuronType.");
 
     // create generator list
-    QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet());
+    QSharedPointer<Generator> spikingNet = QSharedPointer<Generator>(new SpikingNet(0));
     QSharedPointer<QList<QSharedPointer<Generator>>> generators = QSharedPointer<QList<QSharedPointer<Generator>>>(new QList<QSharedPointer<Generator>>());
     generators.get()->append(spikingNet);
 

--- a/DynamicLights/main.cpp
+++ b/DynamicLights/main.cpp
@@ -51,6 +51,8 @@ int main(int argc, char *argv[]) {
     qDebug() << "Built against Qt" << QT_VERSION_STR;
     qDebug() << "Using Qt" << QLibraryInfo::version() << "at runtime";
 
+    qDebug() << "GUI id = " << QThread::currentThreadId();
+
 
     // make Generator virtual class recognizable to QML
     // this line is apparently necessary for the QML engine to receive Generator pointers
@@ -113,18 +115,18 @@ int main(int argc, char *argv[]) {
     oscEngine.moveToThread(oscThread.get());
 
     // connect compute engine to osc engine
-    QObject::connect(&computeEngine, &ComputeEngine::sendOscData, &oscEngine, &OscEngine::sendOscData);
+    QObject::connect(&computeEngine, &ComputeEngine::sendOscData, &oscEngine, &OscEngine::sendOscData, Qt::QueuedConnection);
 
-    QObject::connect(&computeEngine, &ComputeEngine::createOscReceiver, &oscEngine, &OscEngine::createOscReceiver);
-    QObject::connect(&computeEngine, &ComputeEngine::updateOscReceiver, &oscEngine, &OscEngine::updateOscReceiver);
-    QObject::connect(&computeEngine, &ComputeEngine::deleteOscReceiver, &oscEngine, &OscEngine::deleteOscReceiver);
+    QObject::connect(&computeEngine, &ComputeEngine::createOscReceiver, &oscEngine, &OscEngine::createOscReceiver, Qt::QueuedConnection);
+    QObject::connect(&computeEngine, &ComputeEngine::updateOscReceiver, &oscEngine, &OscEngine::updateOscReceiver, Qt::QueuedConnection);
+    QObject::connect(&computeEngine, &ComputeEngine::deleteOscReceiver, &oscEngine, &OscEngine::deleteOscReceiver, Qt::QueuedConnection);
 
-    QObject::connect(&computeEngine, &ComputeEngine::createOscSender, &oscEngine, &OscEngine::createOscSender);
-    QObject::connect(&computeEngine, &ComputeEngine::updateOscSender, &oscEngine, &OscEngine::updateOscSender);
-    QObject::connect(&computeEngine, &ComputeEngine::deleteOscSender, &oscEngine, &OscEngine::deleteOscSender);
+    QObject::connect(&computeEngine, &ComputeEngine::createOscSender, &oscEngine, &OscEngine::createOscSender, Qt::QueuedConnection);
+    QObject::connect(&computeEngine, &ComputeEngine::updateOscSender, &oscEngine, &OscEngine::updateOscSender, Qt::QueuedConnection);
+    QObject::connect(&computeEngine, &ComputeEngine::deleteOscSender, &oscEngine, &OscEngine::deleteOscSender, Qt::QueuedConnection);
 
     // connect osc engine to compute engine
-    QObject::connect(&oscEngine, &OscEngine::recieveOscData, &computeEngine, &ComputeEngine::recieveOscData);
+    QObject::connect(&oscEngine, &OscEngine::recieveOscData, &computeEngine, &ComputeEngine::recieveOscData, Qt::QueuedConnection);
 
     // start compute engine
     computeEngine.start();

--- a/DynamicLights/main.qml
+++ b/DynamicLights/main.qml
@@ -49,15 +49,6 @@ ApplicationWindow {
         color: Stylesheet.colors.darkGrey
     }
 
-    // TODO: move this in OSC rack
-    Connections {
-        target: oscReceiver
-
-        onMessageReceived: {
-            handleMessageReceived(oscAddress, message);
-        }
-    }
-
     // Shortcuts:
     Shortcut {
         sequence: "Esc"

--- a/qosc/OscReceiver.cpp
+++ b/qosc/OscReceiver.cpp
@@ -1,13 +1,23 @@
 #include "OscReceiver.h"
 #include "contrib/oscpack/OscTypes.h"
 #include "contrib/oscpack/OscReceivedElements.h"
+#include <chrono>
+#include <QDebug>
+#include <QThread>
 
 OscReceiver::OscReceiver(quint16 receivePort, QObject* parent) :
         QObject(parent)
 {
+    if(flagDebug) {
+        std::chrono::nanoseconds now = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    std::chrono::system_clock::now().time_since_epoch()
+        );
+
+        qDebug() << "constructor (OscReceiver):\tt = " << now.count() << "\tid = " << QThread::currentThreadId();
+    }
+
     m_udpSocket = new QUdpSocket(this);
     // m_udpSocket->bind(QHostAddress::LocalHost, receivePort);
-    qDebug() << "Listening for OSC on port " << receivePort;
     m_udpSocket->bind(QHostAddress::Any, receivePort);
     connect(m_udpSocket, &QUdpSocket::readyRead, this, &OscReceiver::readyReadCb);
 }
@@ -21,7 +31,6 @@ void OscReceiver::readyReadCb() {
         QString oscAddress;
         this->byteArrayToVariantList(arguments, oscAddress, data);
         emit messageReceived(oscAddress, arguments);
-        qDebug() << "C++OscReceiver Received: " << oscAddress << arguments;
     }
 }
 

--- a/qosc/OscReceiver.cpp
+++ b/qosc/OscReceiver.cpp
@@ -5,7 +5,7 @@
 #include <QDebug>
 #include <QThread>
 
-OscReceiver::OscReceiver(quint16 receivePort, QObject* parent) :
+OscReceiver::OscReceiver(quint16 port, QObject* parent) :
         QObject(parent)
 {
     if(flagDebug) {
@@ -17,9 +17,16 @@ OscReceiver::OscReceiver(quint16 receivePort, QObject* parent) :
     }
 
     m_udpSocket = new QUdpSocket(this);
-    // m_udpSocket->bind(QHostAddress::LocalHost, receivePort);
-    m_udpSocket->bind(QHostAddress::Any, receivePort);
+    m_port = port;
+    m_udpSocket->bind(QHostAddress::Any, m_port);
     connect(m_udpSocket, &QUdpSocket::readyRead, this, &OscReceiver::readyReadCb);
+}
+
+void OscReceiver::setPort(quint16 port)
+{
+    m_port = port;
+    m_udpSocket->close();
+    m_udpSocket->bind(QHostAddress::Any, m_port);
 }
 
 void OscReceiver::readyReadCb() {

--- a/qosc/OscReceiver.h
+++ b/qosc/OscReceiver.h
@@ -24,7 +24,8 @@ public:
      * @brief Constructor.
      * @param receivePort Port number to listen to.
      */
-    explicit OscReceiver(quint16 receivePort, QObject *parent = nullptr);
+    explicit OscReceiver(quint16 port, QObject *parent = nullptr);
+    void setPort(quint16 port);
 
 signals:
     /**
@@ -39,6 +40,8 @@ public slots:
 
 private:
     QUdpSocket* m_udpSocket;
+    quint16 m_port;
+
     void byteArrayToVariantList(QVariantList& outputVariantList, QString& outputOscAddress, const QByteArray& inputByteArray);
 
     bool flagDebug = true;

--- a/qosc/OscReceiver.h
+++ b/qosc/OscReceiver.h
@@ -40,4 +40,6 @@ public slots:
 private:
     QUdpSocket* m_udpSocket;
     void byteArrayToVariantList(QVariantList& outputVariantList, QString& outputOscAddress, const QByteArray& inputByteArray);
+
+    bool flagDebug = true;
 };

--- a/qosc/OscReceiver.h
+++ b/qosc/OscReceiver.h
@@ -44,5 +44,5 @@ private:
 
     void byteArrayToVariantList(QVariantList& outputVariantList, QString& outputOscAddress, const QByteArray& inputByteArray);
 
-    bool flagDebug = true;
+    bool flagDebug = false;
 };

--- a/qosc/OscSender.cpp
+++ b/qosc/OscSender.cpp
@@ -25,6 +25,20 @@ OscSender::OscSender(const QString& hostAddress, quint16 port, QObject *parent) 
     m_udpSocket->connectToHost(QHostAddress(m_hostAddress) , m_port);
 }
 
+void OscSender::setPort(quint16 port)
+{
+    m_port = port;
+    m_udpSocket->disconnectFromHost();
+    m_udpSocket->connectToHost(QHostAddress(m_hostAddress) , m_port);
+}
+
+void OscSender::setHostAddress(const QString& hostAddress)
+{
+    m_hostAddress = hostAddress;
+    m_udpSocket->disconnectFromHost();
+    m_udpSocket->connectToHost(QHostAddress(m_hostAddress) , m_port);
+}
+
 void OscSender::send(const QString& oscAddress, const QVariantList& arguments) {
     QByteArray datagram;
     this->variantListToByteArray(datagram, oscAddress, arguments);

--- a/qosc/OscSender.cpp
+++ b/qosc/OscSender.cpp
@@ -40,6 +40,10 @@ void OscSender::setHostAddress(const QString& hostAddress)
 }
 
 void OscSender::send(const QString& oscAddress, const QVariantList& arguments) {
+    if(flagDebug) {
+        qDebug() << "send (OscSender)\targuments = " << arguments;
+    }
+
     QByteArray datagram;
     this->variantListToByteArray(datagram, oscAddress, arguments);
 

--- a/qosc/OscSender.h
+++ b/qosc/OscSender.h
@@ -30,6 +30,8 @@ public:
      * @param parent
      */
     explicit OscSender(const QString& hostAddress, quint16 port, QObject* parent = nullptr);
+    void setPort(quint16 port);
+    void setHostAddress(const QString& hostAddress);
 
     /**
      * @brief Sends an OSC message to the host and address that this sender is configured to send to.

--- a/qosc/OscSender.h
+++ b/qosc/OscSender.h
@@ -50,4 +50,6 @@ private:
     quint16 m_port;
 
     void variantListToByteArray(QByteArray& outputResult, const QString& oscAddress, const QVariantList& arguments);
+
+    bool flagDebug = true;
 };

--- a/qosc/OscSender.h
+++ b/qosc/OscSender.h
@@ -53,5 +53,5 @@ private:
 
     void variantListToByteArray(QByteArray& outputResult, const QString& oscAddress, const QVariantList& arguments);
 
-    bool flagDebug = true;
+    bool flagDebug = false;
 };


### PR DESCRIPTION
Closes #79, closes #65, closes #9. This implements a multi-threaded OSC backend (the `OscEngine` class) that allows receiving OSC input, feeding it into the generator inputs, and sending OSC from the generator output buffers. This also implements the QProperties necessary to build a UI to edit host address, OSC address, and port settings.

Some caveats that will have to be addressed in the future:
- Disabling OSC input / output is not supported yet, as this has some complex interplay with the code that will enable creating and deleting generators. 
- Automatic naming of input / output adresses using the generator is not supported yet. This implies doing a bit of string processing, but also adding in logic that prevents a user from creating multiple generators with the same name.
- I was unable to fully test the OSC output. It seems like Max has trouble reading number lists, and I haven't been able to get an OSC debugger that supports list data to try and see what is going wrong here. The internal logic behind message sending is confirmed to work as intended (what happens in `OscEngine` and `ComputeEngine`), but there might be a bug with the sender itself (`OscSender`). 

One thing worth mentioning is that `OscEngine` implements some checks for invalid states that could happen if something went wrong with the UI / `ComputeEngine`. If these checks fail they will throw an exception and crash the application. This is meant as a way to prevent subtle, lingering bugs from being hard to detect. Does this fit with the coding style we want, and if so, should we add a few more of these for come of the likely issues for the main classes that give structure to the program? What are @aalex and @sofian's opinions on this? 