### PR TITLE
Fix OSC output bug on Max

### DIFF
--- a/DynamicLights/ComputeEngine.cpp
+++ b/DynamicLights/ComputeEngine.cpp
@@ -151,10 +151,11 @@ void ComputeEngine::loop() {
     for(QList<QSharedPointer<Generator>>::iterator it = generators->begin(); it != generators->end(); it++) {
         QList<QVariant> outputs;
         for(int i = 0; i < (*it)->getOutputSize(); i++) {
-            if(flagDummyOscOutput) {
-                outputs.append(randomUniform(randomGenerator));
+            double value = flagDummyOutputMonitor ? randomUniform(randomGenerator) : (*it)->readOutput(i);
+            if(flagCastOutputToFloat) {
+                outputs.append((float)value);
             } else {
-                outputs.append((*it)->readOutput(i));
+                outputs.append(value);
             }
         }
         emit sendOscData((*it)->getId(), outputs);

--- a/DynamicLights/ComputeEngine.h
+++ b/DynamicLights/ComputeEngine.h
@@ -37,6 +37,7 @@ private:
     bool flagDummyOutputMonitor = false;
     bool flagDummyOscOutput = false;
     bool flagDisableProcessing = false;
+    bool flagCastOutputToFloat = true; // needed for Max as it doesn't support doubles
     std::mt19937 randomGenerator;
 std::uniform_real_distribution<> randomUniform;
 public:


### PR DESCRIPTION
This a bit silly as I thought this would take a week or so to fix, but just as I merged #134 I had an idea... And that was it!

It appears Max doesn't support the `double` type, and just interprets it as a `float` with value 0. The solution is simply to cast the values to float before sending it out. This is enabled by setting `flagCastOutputToFloat` to true in `ComputeEngine.h` (set to true by default). This is probably something we'll want to include in global settings (#89) at some point.